### PR TITLE
Align with low-level sensor specifications

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ Shortname: orientation-sensor
 TR: http://www.w3.org/TR/orientation-sensor/
 Editor: Mikhail Pozdnyakov 78325, Intel Corporation, http://intel.com/
 Editor: Alexander Shalamov 78335, Intel Corporation, http://intel.com/
-Editor: Kenneth Rohde Christiansen      , Intel Corporation, http://intel.com/
+Editor: Kenneth Rohde Christiansen 57705, Intel Corporation, http://intel.com/
 Editor: Anssi Kostiainen 41974, Intel Corporation, http://intel.com/
 Group: dap
 Abstract:
@@ -21,7 +21,7 @@ Markup Shorthands: markdown on
 Inline Github Issues: true
 !Test Suite: <a href="https://github.com/w3c/web-platform-tests/tree/master/orientation-sensor">web-platform-tests on GitHub</a>
 Boilerplate: omit issues-index, omit conformance
-Ignored Vars: sensor_instance
+Ignored Vars: sensor_instance, targetBuffer, x, y, z, w
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
@@ -35,9 +35,6 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: latest reading
     text: sensor
     text: sensor-fusion
-</pre>
-
-<pre class="anchors">
 urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
   type: dfn
     text: acceleration
@@ -49,7 +46,7 @@ urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/gyroscope; spec: GYROSCOPE
   type: dfn
-    text: current angular velocity
+    text: angular velocity
   type: interface
     text: Gyroscope; url: gyroscope
 </pre>
@@ -57,7 +54,7 @@ urlPrefix: https://w3c.github.io/gyroscope; spec: GYROSCOPE
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/magnetometer; spec: MAGNETOMETER
   type: dfn
-    text: geomagnetic field
+    text: magnetic field
   type: interface
     text: Magnetometer; url: magnetometer
 </pre>
@@ -159,8 +156,8 @@ The orientation sensor is a [=high-level=] sensor which is created through [=sen
 of the [=low-level=] motion sensors:
 
  - accelerometer that measures [=acceleration=],
- - gyroscope that measures [=current angular velocity=], and
- - magnetometer that measures [=geomagnetic field=].
+ - gyroscope that measures [=angular velocity=], and
+ - magnetometer that measures [=magnetic field=].
 
 Note: Corresponding [=low-level=] sensors are defined in [[ACCELEROMETER]], [[GYROSCOPE]], and
 [[MAGNETOMETER]]. Regardless, the fusion is platform specific and can happen in software or

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 9260eac3642631ba07cbb9e9b2936efe928153e3" name="generator">
+  <meta content="Bikeshed version a65093ce3e69a8d01029b4650499d152cd9bd39a" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1430,7 +1430,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-14">14 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-15">15 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1446,7 +1446,7 @@ pre.idl.highlight { color: #708090; }
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="78325"><a class="p-name fn u-url url" href="http://intel.com/">Mikhail Pozdnyakov</a> (<span class="p-org org">Intel Corporation</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="78335"><a class="p-name fn u-url url" href="http://intel.com/">Alexander Shalamov</a> (<span class="p-org org">Intel Corporation</span>)
-     <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="http://intel.com/">Kenneth Rohde Christiansen</a> (<span class="p-org org">Intel Corporation</span>)
+     <dd class="editor p-author h-card vcard" data-editor-id="57705"><a class="p-name fn u-url url" href="http://intel.com/">Kenneth Rohde Christiansen</a> (<span class="p-org org">Intel Corporation</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="41974"><a class="p-name fn u-url url" href="http://intel.com/">Anssi Kostiainen</a> (<span class="p-org org">Intel Corporation</span>)
      <dt>Bug Reports:
      <dd><span><a href="https://www.github.com/w3c/orientation-sensor/issues/new">via the w3c/orientation-sensor repository on GitHub</a></span>
@@ -1574,9 +1574,9 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
     <li data-md="">
      <p>accelerometer that measures <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#acceleration">acceleration</a>,</p>
     <li data-md="">
-     <p>gyroscope that measures <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#current-angular-velocity">current angular velocity</a>, and</p>
+     <p>gyroscope that measures <a data-link-type="dfn" href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a>, and</p>
     <li data-md="">
-     <p>magnetometer that measures <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#geomagnetic-field">geomagnetic field</a>.</p>
+     <p>magnetometer that measures <a data-link-type="dfn" href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a>.</p>
    </ul>
    <p class="note" role="note"><span>Note:</span> Corresponding <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level">low-level</a> sensors are defined in <a data-link-type="biblio" href="#biblio-accelerometer">[ACCELEROMETER]</a>, <a data-link-type="biblio" href="#biblio-gyroscope">[GYROSCOPE]</a>, and <a data-link-type="biblio" href="#biblio-magnetometer">[MAGNETOMETER]</a>. Regardless, the fusion is platform specific and can happen in software or
 hardware, i.e. on a sensor hub.</p>
@@ -1788,7 +1788,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[GYROSCOPE]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/gyroscope#current-angular-velocity">current angular velocity</a>
+     <li><a href="https://w3c.github.io/gyroscope#angular-velocity">angular velocity</a>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
@@ -1801,7 +1801,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[MAGNETOMETER]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/magnetometer#geomagnetic-field">geomagnetic field</a>
+     <li><a href="https://w3c.github.io/magnetometer#magnetic-field">magnetic field</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:


### PR DESCRIPTION
This PR aligns OrientationSensor specification with references defined in low-level sensor specs.
- current angular velocity => angular velocity
- geomagnetic field => magnetic field
- fixes for bikeshed warnings


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/orientation-sensor/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/orientation-sensor/744809b...alexshalamov:9fe0369.html)