### PR TITLE
Convert the 'populateQuaternion' function to 'quaternion' attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -202,26 +202,15 @@ The OrientationSensor Interface {#orientationsensor-interface}
 
 <pre class="idl">
   interface OrientationSensor : Sensor {
-    void populateQuaternion(Float32Array targetBuffer);
+    readonly attribute Float32Array? quaternion;
     void populateMatrix(Float32Array targetBuffer);
   };
 </pre>
 
-### OrientationSensor.populateQuaternion() ### {#orientationsensor-populatequaternion}
+### OrientationSensor.quaternion ### {#orientationsensor-quaternion}
 
-<div algorithm="to populate quaternion">
-The {{OrientationSensor/populateQuaternion()}} method must run these steps or their [=equivalent=]:
-    1.  If |targetBuffer| is not of type {{Float32Array}}, [=throw=] a
-        "{{SyntaxError!!exception}}" {{DOMException}} and abort these steps.
-    1.  If |targetBuffer| is of type {{Float32Array}} with a size less than four, [=throw=] a
-        "{{TypeError!!exception}}" {{DOMException}} and abort these steps.
-    1.  If the value of |sensor_instance|.[=[[state]]=] is not <a enum-value>"activated"</a>,
-        [=throw=] an "{{InvalidStateError!!exception}}" {{DOMException}} and abort these steps.
-    1.  Run these sub-steps:
-        1.  Let |quaternion| be the value of [=latest reading=]["quaternion"]
-        1.  If |quaternion| is `null`, abort these steps.
-        1.  Copy |quaternion| into |targetBuffer|
-</div>
+Returns a four-element array the elements of which contain the components of the unit quaternion representing the device orientation.
+In other words, this attribute returns [=latest reading=]["quaternion"].
 
 ### OrientationSensor.populateMatrix() ### {#orientationsensor-populatematrix}
 

--- a/index.html
+++ b/index.html
@@ -1430,7 +1430,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-16">16 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-20">20 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1499,7 +1499,7 @@ physical orientation in relation to a stationary three dimensional Cartesian coo
       <li>
        <a href="#orientationsensor-interface"><span class="secno">5.1</span> <span class="content">The OrientationSensor Interface</span></a>
        <ol class="toc">
-        <li><a href="#orientationsensor-populatequaternion"><span class="secno">5.1.1</span> <span class="content">OrientationSensor.populateQuaternion()</span></a>
+        <li><a href="#orientationsensor-quaternion"><span class="secno">5.1.1</span> <span class="content">OrientationSensor.quaternion</span></a>
         <li><a href="#orientationsensor-populatematrix"><span class="secno">5.1.2</span> <span class="content">OrientationSensor.populateMatrix()</span></a>
        </ol>
       <li><a href="#absoluteorientationsensor-interface"><span class="secno">5.2</span> <span class="content">The AbsoluteOrientationSensor Interface</span></a>
@@ -1603,34 +1603,13 @@ orientation sensor’s <a data-link-type="dfn" href="https://w3c.github.io/senso
    <h2 class="heading settled" data-level="5" id="api"><span class="secno">5. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="orientationsensor-interface"><span class="secno">5.1. </span><span class="content">The OrientationSensor Interface</span><a class="self-link" href="#orientationsensor-interface"></a></h3>
 <pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="orientationsensor">OrientationSensor</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="OrientationSensor" data-dfn-type="method" data-export="" data-lt="populateQuaternion(targetBuffer)" id="dom-orientationsensor-populatequaternion">populateQuaternion</dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Float32Array"><span class="kt">Float32Array</span></a> <dfn class="nv idl-code" data-dfn-for="OrientationSensor/populateQuaternion(targetBuffer)" data-dfn-type="argument" data-export="" id="dom-orientationsensor-populatequaternion-targetbuffer-targetbuffer">targetBuffer<a class="self-link" href="#dom-orientationsensor-populatequaternion-targetbuffer-targetbuffer"></a></dfn>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Float32Array"><span class="kt">Float32Array</span></a>? <dfn class="nv idl-code" data-dfn-for="OrientationSensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Float32Array?" id="dom-orientationsensor-quaternion">quaternion<a class="self-link" href="#dom-orientationsensor-quaternion"></a></dfn>;
   <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="OrientationSensor" data-dfn-type="method" data-export="" data-lt="populateMatrix(targetBuffer)" id="dom-orientationsensor-populatematrix">populateMatrix</dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Float32Array"><span class="kt">Float32Array</span></a> <dfn class="nv idl-code" data-dfn-for="OrientationSensor/populateMatrix(targetBuffer)" data-dfn-type="argument" data-export="" id="dom-orientationsensor-populatematrix-targetbuffer-targetbuffer">targetBuffer<a class="self-link" href="#dom-orientationsensor-populatematrix-targetbuffer-targetbuffer"></a></dfn>);
 };
 </pre>
-   <h4 class="heading settled" data-level="5.1.1" id="orientationsensor-populatequaternion"><span class="secno">5.1.1. </span><span class="content">OrientationSensor.populateQuaternion()</span><a class="self-link" href="#orientationsensor-populatequaternion"></a></h4>
-   <div class="algorithm" data-algorithm="to populate quaternion">
-     The <code class="idl"><a data-link-type="idl" href="#dom-orientationsensor-populatequaternion" id="ref-for-dom-orientationsensor-populatequaternion-1">populateQuaternion()</a></code> method must run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sensors#equivalent">equivalent</a>: 
-    <ol>
-     <li data-md="">
-      <p>If <var>targetBuffer</var> is not of type <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Float32Array">Float32Array</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
-  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
-     <li data-md="">
-      <p>If <var>targetBuffer</var> is of type <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Float32Array">Float32Array</a></code> with a size less than four, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
-  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
-     <li data-md="">
-      <p>If the value of <var>sensor_instance</var>.<a data-link-type="dfn" href="https://w3c.github.io/sensors/#state">[[state]]</a> is not <a class="idl-code" data-link-type="enum-value" href="https://w3c.github.io/sensors/#dom-sensorstate-activated">"activated"</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
-     <li data-md="">
-      <p>Run these sub-steps:</p>
-      <ol>
-       <li data-md="">
-        <p>Let <var>quaternion</var> be the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["quaternion"]</p>
-       <li data-md="">
-        <p>If <var>quaternion</var> is <code>null</code>, abort these steps.</p>
-       <li data-md="">
-        <p>Copy <var>quaternion</var> into <var>targetBuffer</var></p>
-      </ol>
-    </ol>
-   </div>
+   <h4 class="heading settled" data-level="5.1.1" id="orientationsensor-quaternion"><span class="secno">5.1.1. </span><span class="content">OrientationSensor.quaternion</span><a class="self-link" href="#orientationsensor-quaternion"></a></h4>
+   <p>Returns a four-element array the elements of which contain the components of the unit quaternion representing the device orientation.
+In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["quaternion"].</p>
    <h4 class="heading settled" data-level="5.1.2" id="orientationsensor-populatematrix"><span class="secno">5.1.2. </span><span class="content">OrientationSensor.populateMatrix()</span><a class="self-link" href="#orientationsensor-populatematrix"></a></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-orientationsensor-populatematrix" id="ref-for-dom-orientationsensor-populatematrix-1">populateMatrix()</a></code> method  populates the given buffer with WebGL-compatible rotation matrix
 which is converted from the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["quaternion"] <a data-link-type="biblio" href="#biblio-quatconv">[QUATCONV]</a>, as shown below</p>
@@ -1760,7 +1739,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li><a href="#earths-reference-coordinate-system">Earth’s reference coordinate system</a><span>, in §4</span>
    <li><a href="#orientationsensor">OrientationSensor</a><span>, in §5.1</span>
    <li><a href="#dom-orientationsensor-populatematrix">populateMatrix(targetBuffer)</a><span>, in §5.1</span>
-   <li><a href="#dom-orientationsensor-populatequaternion">populateQuaternion(targetBuffer)</a><span>, in §5.1</span>
+   <li><a href="#dom-orientationsensor-quaternion">quaternion</a><span>, in §5.1</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -1857,7 +1836,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl def"><span class="kt">interface</span> <a class="nv" href="#orientationsensor">OrientationSensor</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">void</span> <a class="nv" href="#dom-orientationsensor-populatequaternion">populateQuaternion</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Float32Array"><span class="kt">Float32Array</span></a> <a class="nv" href="#dom-orientationsensor-populatequaternion-targetbuffer-targetbuffer">targetBuffer</a>);
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Float32Array"><span class="kt">Float32Array</span></a>? <a class="nv" data-readonly="" data-type="Float32Array?" href="#dom-orientationsensor-quaternion">quaternion</a>;
   <span class="kt">void</span> <a class="nv" href="#dom-orientationsensor-populatematrix">populateMatrix</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-Float32Array"><span class="kt">Float32Array</span></a> <a class="nv" href="#dom-orientationsensor-populatematrix-targetbuffer-targetbuffer">targetBuffer</a>);
 };
 
@@ -1879,12 +1858,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-orientationsensor-1">1. Introduction</a> <a href="#ref-for-orientationsensor-2">(2)</a> <a href="#ref-for-orientationsensor-3">(3)</a> <a href="#ref-for-orientationsensor-4">(4)</a>
     <li><a href="#ref-for-orientationsensor-5">4. Model</a> <a href="#ref-for-orientationsensor-6">(2)</a>
     <li><a href="#ref-for-orientationsensor-7">5.2. The AbsoluteOrientationSensor Interface</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-orientationsensor-populatequaternion">
-   <b><a href="#dom-orientationsensor-populatequaternion">#dom-orientationsensor-populatequaternion</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-orientationsensor-populatequaternion-1">5.1.1. OrientationSensor.populateQuaternion()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-orientationsensor-populatematrix">


### PR DESCRIPTION
The attribute will be more convenient to use.

The main reason for the previous using of BYOB was the potential GC issues, now BYOB here seems to be unnecessary:  https://github.com/w3c/sensors/issues/153#issuecomment-287780164


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/orientation-sensor/quaternion_attribute.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/orientation-sensor/66077ee...pozdnyakov:7cb02dc.html)