### PR TITLE
Return quaternion as [x,y,z,w]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -190,7 +190,7 @@ The OrientationSensor has an associated {{PermissionName}} which is <a for="Perm
 A [=latest reading=] per [=sensor=] of orientation type includes an [=map/entry=]
 whose [=map/key=] is "quaternion" and whose [=map/value=] contains a four element [=list=].
 The elements of the [=list=] are equal to components of a unit quaternion [[QUATERNIONS]]
-[cos(θ/2), V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2)] where V is
+[V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2), cos(θ/2)] where V is
 the unit vector representing the axis of rotation.
 
 The {{AbsoluteOrientationSensor}} class is a subclass of {{OrientationSensor}} which represents the [=Absolute
@@ -267,10 +267,10 @@ run these steps or their [=equivalent=]:
         "{{TypeError!!exception}}" {{DOMException}} and abort these steps.
     1.  Let |quaternion| be the value of [=latest reading=]["quaternion"]
     1.  If |quaternion| is `null`, [=throw=] a "{{NotReadableError!!exception}}" {{DOMException}} and abort these steps.
-    1.  Let |w| be the value of |quaternion|[0]
-    1.  Let |x| be the value of |quaternion|[1]
-    1.  Let |y| be the value of |quaternion|[2]
-    1.  Let |z| be the value of |quaternion|[3]
+    1.  Let |x| be the value of |quaternion|[0]
+    1.  Let |y| be the value of |quaternion|[1]
+    1.  Let |z| be the value of |quaternion|[2]
+    1.  Let |w| be the value of |quaternion|[3]
     1.  If |targetMatrix| is of  {{Float32Array}} or {{Float64Array}} type, run these sub-steps:
         1.  Set |targetMatrix|[0] = 1 - 2 * y * y - 2 * z * z
         1.  Set |targetMatrix|[1] = 2 * x * y - 2 * z * w

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 588c13f032a881310dc4886e2269c4ffd3b6784b" name="generator">
+  <meta content="Bikeshed version 81c00a31d8c468599cf8337dd150a8be9a2b4e5d" name="generator">
   <link href="http://www.w3.org/TR/orientation-sensor/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1431,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-05">5 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-07">7 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1587,7 +1587,7 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
 representing device orientation data.</p>
    <p>The OrientationSensor has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code> which is <a class="idl-code" data-link-type="enum-value">"orientation-sensor"</a>.</p>
    <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of orientation type includes an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "quaternion" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> contains a four element <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a>.
-The elements of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> are equal to components of a unit quaternion <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a> [cos(θ/2), V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2)] where V is
+The elements of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> are equal to components of a unit quaternion <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a> [V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2), cos(θ/2)] where V is
 the unit vector representing the axis of rotation.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor-2">AbsoluteOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor-6">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#absolute-orientation">Absolute
 Orientation Sensor</a>.</p>
@@ -1659,13 +1659,13 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
      <li data-md="">
       <p>If <var>quaternion</var> is <code>null</code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
      <li data-md="">
-      <p>Let <var>w</var> be the value of <var>quaternion</var>[0]</p>
+      <p>Let <var>x</var> be the value of <var>quaternion</var>[0]</p>
      <li data-md="">
-      <p>Let <var>x</var> be the value of <var>quaternion</var>[1]</p>
+      <p>Let <var>y</var> be the value of <var>quaternion</var>[1]</p>
      <li data-md="">
-      <p>Let <var>y</var> be the value of <var>quaternion</var>[2]</p>
+      <p>Let <var>z</var> be the value of <var>quaternion</var>[2]</p>
      <li data-md="">
-      <p>Let <var>z</var> be the value of <var>quaternion</var>[3]</p>
+      <p>Let <var>w</var> be the value of <var>quaternion</var>[3]</p>
      <li data-md="">
       <p>If <var>targetMatrix</var> is of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Float32Array">Float32Array</a></code> or <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Float64Array">Float64Array</a></code> type, run these sub-steps:</p>
       <ol>


### PR DESCRIPTION
Fixes #29


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/orientation-sensor/fix_29.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/orientation-sensor/ec47469...pozdnyakov:058f94a.html)