### PR TITLE
Fix #31 Throw TypeError when invalid type is provided to populateMatrix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -262,7 +262,7 @@ The rotation matrix is flattened in |targetMatrix| object according to the colum
 To <dfn>populate rotation matrix</dfn>, the {{OrientationSensor/populateMatrix()}} method must
 run these steps or their [=equivalent=]:
     1.  If |targetMatrix| is not of type defined by {{RotationMatrixType}} union, [=throw=] a
-        "{{SyntaxError!!exception}}" {{DOMException}} and abort these steps.
+        "{{TypeError!!exception}}" {{DOMException}} and abort these steps.
     1.  If |targetMatrix| is of type {{Float32Array}} or {{Float64Array}} with a size less than sixteen, [=throw=] a
         "{{TypeError!!exception}}" {{DOMException}} and abort these steps.
     1.  Let |quaternion| be the value of [=latest reading=]["quaternion"]

--- a/index.html
+++ b/index.html
@@ -1431,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-07">7 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-10">10 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1650,7 +1650,7 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
     <ol>
      <li data-md="">
       <p>If <var>targetMatrix</var> is not of type defined by <code class="idl"><a data-link-type="idl" href="#typedefdef-rotationmatrixtype" id="ref-for-typedefdef-rotationmatrixtype-2">RotationMatrixType</a></code> union, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
-  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
+  "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
      <li data-md="">
       <p>If <var>targetMatrix</var> is of type <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Float32Array">Float32Array</a></code> or <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Float64Array">Float64Array</a></code> with a size less than sixteen, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a
   "<code class="idl"><a class="idl-code" data-link-type="exception" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a></code> and abort these steps.</p>
@@ -1850,7 +1850,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://heycam.github.io/webidl/#idl-Float64Array">Float64Array</a>
      <li><a href="https://heycam.github.io/webidl/#idl-frozen-array">FrozenArray</a>
      <li><a href="https://heycam.github.io/webidl/#notreadableerror">NotReadableError</a>
-     <li><a href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a>
      <li><a href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a>
      <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/orientation-sensor/use_type_exception.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/orientation-sensor/099ee58...pozdnyakov:e426a07.html)