### PR TITLE
Add a note explaining the quaternion components order used

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -193,6 +193,12 @@ The elements of the [=list=] are equal to components of a unit quaternion [[QUAT
 [V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2), cos(θ/2)] where V is
 the unit vector representing the axis of rotation.
 
+Note: The quaternion components are arranged in the [=list=] as [q<sub>1</sub>, q<sub>2</sub>, q<sub>3</sub>, q<sub>0</sub>]
+[[QUATERNIONS]], i.e. the components representing the vector part of the quaternion go first and the scalar part component which
+is equal to cos(θ/2) goes after. This order is used for better compatibility with the most of the existing WebGL frameworks,
+however other libraries could use a different order when exposing quaternion as an array, e.g. [q<sub>0</sub>, q<sub>1</sub>,
+q<sub>2</sub>, q<sub>3</sub>].
+
 The {{AbsoluteOrientationSensor}} class is a subclass of {{OrientationSensor}} which represents the [=Absolute
 Orientation Sensor=].
 

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 81c00a31d8c468599cf8337dd150a8be9a2b4e5d" name="generator">
+  <meta content="Bikeshed version 6034b36946b93e3f3c8a37a5edec3d6c96ad1891" name="generator">
   <link href="http://www.w3.org/TR/orientation-sensor/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1431,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-10">10 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-12">12 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1589,6 +1589,10 @@ representing device orientation data.</p>
    <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of orientation type includes an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "quaternion" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> contains a four element <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a>.
 The elements of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> are equal to components of a unit quaternion <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a> [V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2), cos(θ/2)] where V is
 the unit vector representing the axis of rotation.</p>
+   <p class="note" role="note"><span>Note:</span> The quaternion components are arranged in the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> as [q<sub>1</sub>, q<sub>2</sub>, q<sub>3</sub>, q<sub>0</sub>] <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a>, i.e. the components representing the vector part of the quaternion go first and the scalar part component which
+is equal to cos(θ/2) goes after. This order is used for better compatibility with the most of the existing WebGL frameworks,
+however other libraries could use a different order when exposing quaternion as an array, e.g. [q<sub>0</sub>, q<sub>1</sub>,
+q<sub>2</sub>, q<sub>3</sub>].</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor-2">AbsoluteOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor-6">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#absolute-orientation">Absolute
 Orientation Sensor</a>.</p>
    <p>The absolute orientation sensor is a <a data-link-type="dfn" href="https://w3c.github.io/sensors#high-level">high-level</a> sensor which is created through <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-fusion">sensor-fusion</a> of the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level">low-level</a> motion sensors:</p>


### PR DESCRIPTION
Fixes #29


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pozdnyakov/orientation-sensor/add_quat_note.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/orientation-sensor/632034f...pozdnyakov:6595a66.html)