### PR TITLE
Use low-level sensor permission tokens for orientation sensor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -185,7 +185,21 @@ Model {#model}
 The {{OrientationSensor}} class extends the {{Sensor}} class and provides generic interface
 representing device orientation data.
 
-The OrientationSensor has an associated {{PermissionName}} which is <a for="PermissionName" enum-value>"orientation-sensor"</a>.
+To access orientation sensor's [=latest reading=], user agent must invoke [=request sensor access=] abstract operation for each of the [=low-level=] sensors used by the concrete orientation sensor. The table below
+describes mapping between concrete orientation sensors and permission tokens defined by [=low-level=] sensors.
+
+<table class="def">
+  <thead>
+    <th>OrientationSensor sublass</th>
+    <th>Permission tokens</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{AbsoluteOrientationSensor}}</td>
+      <td>"accelerometer", "gyroscope", "magnetometer"</td>
+    </tr>
+  </tbody>
+</table>
 
 A [=latest reading=] per [=sensor=] of orientation type includes an [=map/entry=]
 whose [=map/key=] is "quaternion" and whose [=map/value=] contains a four element [=list=].

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 6034b36946b93e3f3c8a37a5edec3d6c96ad1891" name="generator">
+  <meta content="Bikeshed version e005ff11b3a57cb2e97504fd3b294df06e165037" name="generator">
   <link href="http://www.w3.org/TR/orientation-sensor/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1431,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-12">12 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-13">13 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1585,7 +1585,18 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
    <h2 class="heading settled" data-level="5" id="model"><span class="secno">5. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p>The <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor-5">OrientationSensor</a></code> class extends the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor">Sensor</a></code> class and provides generic interface
 representing device orientation data.</p>
-   <p>The OrientationSensor has an associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a></code> which is <a class="idl-code" data-link-type="enum-value">"orientation-sensor"</a>.</p>
+   <p>To access orientation sensor’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>, user agent must invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors/#request-sensor-access">request sensor access</a> abstract operation for each of the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level">low-level</a> sensors used by the concrete orientation sensor. The table below
+describes mapping between concrete orientation sensors and permission tokens defined by <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level">low-level</a> sensors.</p>
+   <table class="def">
+    <thead>
+     <tr>
+      <th>OrientationSensor sublass
+      <th>Permission tokens
+    <tbody>
+     <tr>
+      <td><code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor-2">AbsoluteOrientationSensor</a></code>
+      <td>"accelerometer", "gyroscope", "magnetometer"
+   </table>
    <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of orientation type includes an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">key</a> is "quaternion" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">value</a> contains a four element <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a>.
 The elements of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> are equal to components of a unit quaternion <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a> [V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2), cos(θ/2)] where V is
 the unit vector representing the axis of rotation.</p>
@@ -1593,7 +1604,7 @@ the unit vector representing the axis of rotation.</p>
 is equal to cos(θ/2) goes after. This order is used for better compatibility with the most of the existing WebGL frameworks,
 however other libraries could use a different order when exposing quaternion as an array, e.g. [q<sub>0</sub>, q<sub>1</sub>,
 q<sub>2</sub>, q<sub>3</sub>].</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor-2">AbsoluteOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor-6">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#absolute-orientation">Absolute
+   <p>The <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor-3">AbsoluteOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor-6">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#absolute-orientation">Absolute
 Orientation Sensor</a>.</p>
    <p>The absolute orientation sensor is a <a data-link-type="dfn" href="https://w3c.github.io/sensors#high-level">high-level</a> sensor which is created through <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-fusion">sensor-fusion</a> of the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level">low-level</a> motion sensors:</p>
    <ul>
@@ -1812,6 +1823,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
+     <li><a href="https://w3c.github.io/sensors/#request-sensor-access">request sensor access</a>
     </ul>
    <li>
     <a data-link-type="biblio">[geometry-1]</a> defines the following terms:
@@ -1842,11 +1854,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://w3c.github.io/motion-sensors#absolute-orientation">absolute orientation sensor</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[permissions]</a> defines the following terms:
-    <ul>
-     <li><a href="https://w3c.github.io/permissions/#enumdef-permissionname">PermissionName</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
@@ -1874,8 +1881,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-magnetometer">[MAGNETOMETER]
    <dd>Anssi Kostiainen; Rijubrata Bhaumik. <a href="https://www.w3.org/TR/magnetometer/">Magnetometer Sensor</a>. URL: <a href="https://www.w3.org/TR/magnetometer/">https://www.w3.org/TR/magnetometer/</a>
-   <dt id="biblio-permissions">[PERMISSIONS]
-   <dd>Mounir Lamouri; Marcos Caceres. <a href="https://www.w3.org/TR/permissions/">The Permissions API</a>. URL: <a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WEBIDL]
@@ -1940,7 +1945,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <b><a href="#absoluteorientationsensor">#absoluteorientationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor-1">1. Introduction</a>
-    <li><a href="#ref-for-absoluteorientationsensor-2">5. Model</a>
+    <li><a href="#ref-for-absoluteorientationsensor-2">5. Model</a> <a href="#ref-for-absoluteorientationsensor-3">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
Fixes #33


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/orientation-sensor/use_granular_tokens.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/orientation-sensor/39d788b...alexshalamov:2e31a20.html)