### PR TITLE
Orientation sensors can use the screen local coordinates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -36,10 +36,12 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: latest reading
     text: sensor-fusion
     text: sensor type
+    text: local coordinate system
 urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
   type: dfn
     text: acceleration
-    text: local coordinate system
+    text: device coordinate system
+    text: screen coordinate system
   type: interface
     text: Accelerometer; url: accelerometer
 </pre>
@@ -285,17 +287,19 @@ The AbsoluteOrientationSensor Model {#absoluteorientationsensor-model}
 The {{AbsoluteOrientationSensor}} class is a subclass of {{OrientationSensor}} which represents
 the [=Absolute Orientation Sensor=].
 
-For the absolute orientation sensor the value of [=latest reading=]["quaternion"] represents the rotation of a
-device hosting motion sensors in relation to the <dfn>Earth's reference coordinate system</dfn> defined as a
-three dimensional Cartesian coordinate system (x, y, z), where:
+For the absolute orientation sensor the value of [=latest reading=]["quaternion"] represents
+the rotation of a device's [=local coordinate system=] in relation to the <dfn>Earth's reference
+coordinate system</dfn> defined as a three dimensional Cartesian coordinate system (x, y, z), where:
 
  - x-axis is a vector product of y.z that is tangential to the ground and points east,
  - y-axis is tangential to the ground and points towards magnetic north, and
  - z-axis points towards the sky and is perpendicular to the plane made up of x and y axes.
 
-The device's <a>local coordinate system</a> is the same as defined by [=low-level=] motion sensors.
+The device's [=local coordinate system=] is the same as defined for the [=low-level=]
+motion sensors. It can be either the [=device coordinate system=] or the
+[=screen coordinate system=].
 
-Note: Figure below represents the case where device's <a>local coordinate system</a> and the <a>Earth's reference coordinate system</a> are aligned, therefore,
+Note: Figure below represents the case where device's [=local coordinate system=] and the <a>Earth's reference coordinate system</a> are aligned, therefore,
 orientation sensor's [=latest reading=] would represent 0 (rad) [[SI]] rotation about each axis.
 
 <img src="images/absolute_orientation_sensor_coordinate_system.png" srcset="images/absolute_orientation_sensor_coordinate_system.svg" style="display: block;margin: auto;" alt="AbsoluteOrientationSensor coordinate system.">
@@ -307,13 +311,17 @@ The {{RelativeOrientationSensor}} class is a subclass of {{OrientationSensor}} w
 [=Relative Orientation Sensor=].
 
 For the relative orientation sensor the value of [=latest reading=]["quaternion"] represents the
-rotation of a device hosting motion sensors in relation to a [=stationary reference coordinate
+rotation of a device's [=local coordinate system=] in relation to a [=stationary reference coordinate
 system=]. The [=stationary reference coordinate system=] may drift due to the bias introduced by
 the gyroscope sensor, thus, the rotation value provided by the sensor, may drift over time.
 
 The <dfn>stationary reference coordinate system</dfn> is defined as an inertial three dimensional
 Cartesian coordinate system that remains stationary as the device hosting the sensor moves through
 the environment.
+
+The device's [=local coordinate system=] is the same as defined for the [=low-level=]
+motion sensors. It can be either the [=device coordinate system=] or the
+[=screen coordinate system=].
 
 Note: The relative orientation sensor data could be more accurate than the one provided by absolute
 orientation sensor, as the sensor is not affected by magnetic fields.
@@ -331,6 +339,12 @@ The OrientationSensor Interface {#orientationsensor-interface}
   interface OrientationSensor : Sensor {
     readonly attribute FrozenArray&lt;double>? quaternion;
     void populateMatrix(RotationMatrixType targetMatrix);
+  };
+
+  enum LocalCoordinateSystem { "device", "screen" };
+
+  dictionary OrientationSensorOptions : SensorOptions  {
+    LocalCoordinateSystem referenceFrame = "device";
   };
 </pre>
 
@@ -414,25 +428,45 @@ The AbsoluteOrientationSensor Interface {#absoluteorientationsensor-interface}
 -------------------------------------
 
 <pre class="idl">
-  [Constructor(optional SensorOptions sensorOptions), SecureContext, Exposed=Window]
+  [Constructor(optional OrientationSensorOptions sensorOptions), SecureContext, Exposed=Window]
   interface AbsoluteOrientationSensor : OrientationSensor {
   };
 </pre>
 
-To <dfn>Construct an AbsoluteOrientationSensor Object</dfn> the user agent must invoke the
-<a>construct a Sensor object</a> abstract operation.
+To construct an {{AbsoluteOrientationSensor}} object the user agent must invoke the
+[=construct an orientation sensor object=] abstract operation.
 
 The RelativeOrientationSensor Interface {#relativeorientationsensor-interface}
 -------------------------------------
 
 <pre class="idl">
-  [Constructor(optional SensorOptions sensorOptions), SecureContext, Exposed=Window]
+  [Constructor(optional OrientationSensorOptions sensorOptions), SecureContext, Exposed=Window]
   interface RelativeOrientationSensor : OrientationSensor {
   };
 </pre>
 
-To <dfn>Construct an RelativeOrientationSensor Object</dfn> the user agent must invoke the
-<a>construct a Sensor object</a> abstract operation.
+To construct a {{RelativeOrientationSensor}} object the user agent must invoke the
+[=construct an orientation sensor object=] abstract operation.
+
+Abstract Operations {#abstract-operations}
+===================
+
+<h3 dfn export>Construct an Orientation Sensor object</h3>
+
+<div algorithm="construct an orientation sensor object">
+
+    : input
+    :: |options|, a {{OrientationSensorOptions}} object.
+    : output
+    :: A {{Sensor}} object.
+
+    1. Let |sensor_instance| be the result of invoking [=construct a Sensor object=] with |options|.
+    1. If |options|.{{referenceFrame!!dict-member}} is "screen", then:
+       1.  Define [=local coordinate system=] for |sensor_instance|
+           as the [=screen coordinate system=].
+    1. Otherwise, define [=local coordinate system=] for |sensor_instance|
+       as the [=device coordinate system=].
+</div>
 
 Acknowledgements {#acknowledgements}
 ================

--- a/index.html
+++ b/index.html
@@ -1183,9 +1183,8 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 2d63ad75df4c3282ed7d8d3fb42b0c483a131ce1" name="generator">
+  <meta content="Bikeshed version 166744eb86a34dbc5493268ea410dc65275aa964" name="generator">
   <link href="https://www.w3.org/TR/orientation-sensor/" rel="canonical">
-  <meta content="0e6131388b8601de0f1e76d93363b432e227e062" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1432,7 +1431,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-18">18 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-08">8 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1459,7 +1458,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -1482,11 +1481,11 @@ physical orientation in relation to a stationary three dimensional Cartesian coo
 	All comments are welcome. </p>
    <p> This document was produced by the <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
+	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1515,8 +1514,13 @@ physical orientation in relation to a stationary three dimensional Cartesian coo
       <li><a href="#absoluteorientationsensor-interface"><span class="secno">6.2</span> <span class="content">The AbsoluteOrientationSensor Interface</span></a>
       <li><a href="#relativeorientationsensor-interface"><span class="secno">6.3</span> <span class="content">The RelativeOrientationSensor Interface</span></a>
      </ol>
-    <li><a href="#acknowledgements"><span class="secno">7</span> <span class="content">Acknowledgements</span></a>
-    <li><a href="#conformance"><span class="secno">8</span> <span class="content">Conformance</span></a>
+    <li>
+     <a href="#abstract-operations"><span class="secno">7</span> <span class="content">Abstract Operations</span></a>
+     <ol class="toc">
+      <li><a href="#construct-an-orientation-sensor-object"><span class="secno">7.1</span> <span class="content">Construct an Orientation Sensor object</span></a>
+     </ol>
+    <li><a href="#acknowledgements"><span class="secno">8</span> <span class="content">Acknowledgements</span></a>
+    <li><a href="#conformance"><span class="secno">9</span> <span class="content">Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1634,8 +1638,8 @@ q<sub>2</sub>, q<sub>3</sub>].</p>
    </table>
    <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer#accelerometer" id="ref-for-accelerometer②">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope#gyroscope" id="ref-for-gyroscope②">Gyroscope</a></code> and <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/magnetometer#magnetometer" id="ref-for-magnetometer①">Magnetometer</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑤">low-level</a> sensors are defined in <a data-link-type="biblio" href="#biblio-accelerometer">[ACCELEROMETER]</a>, <a data-link-type="biblio" href="#biblio-gyroscope">[GYROSCOPE]</a>, and <a data-link-type="biblio" href="#biblio-magnetometer">[MAGNETOMETER]</a> specifications respectively. The <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-fusion" id="ref-for-sensor-fusion①">sensor fusion</a> is platform specific and can happen in software or hardware, i.e.
 on a sensor hub.</p>
-   <div class="example" id="example-a5b53191">
-    <a class="self-link" href="#example-a5b53191"></a> This example code explicitly queries permissions for <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor③">AbsoluteOrientationSensor</a></code> before
+   <div class="example" id="example-501d0803">
+    <a class="self-link" href="#example-501d0803"></a> This example code explicitly queries permissions for <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor③">AbsoluteOrientationSensor</a></code> before
     calling <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#dom-sensor-start" id="ref-for-dom-sensor-start">start()</a></code>. 
 <pre class="highlight"><span class="kr">const</span> sensor <span class="o">=</span> <span class="k">new</span> AbsoluteOrientationSensor<span class="p">();</span>
 Promise<span class="p">.</span>all<span class="p">([</span>navigator<span class="p">.</span>permissions<span class="p">.</span>query<span class="p">({</span> name<span class="o">:</span> <span class="s2">"accelerometer"</span> <span class="p">}),</span>
@@ -1662,9 +1666,9 @@ sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class
    <h3 class="heading settled" data-level="5.1" id="absoluteorientationsensor-model"><span class="secno">5.1. </span><span class="content">The AbsoluteOrientationSensor Model</span><a class="self-link" href="#absoluteorientationsensor-model"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor④">AbsoluteOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑥">OrientationSensor</a></code> which represents
 the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#absolute-orientation" id="ref-for-absolute-orientation">Absolute Orientation Sensor</a>.</p>
-   <p>For the absolute orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading②">latest reading</a>["quaternion"] represents the rotation of a
-device hosting motion sensors in relation to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="earths-reference-coordinate-system">Earth’s reference coordinate system</dfn> defined as a
-three dimensional Cartesian coordinate system (x, y, z), where:</p>
+   <p>For the absolute orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading②">latest reading</a>["quaternion"] represents
+the rotation of a device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> in relation to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Earth’s reference coordinate system" data-noexport="" id="earths-reference-coordinate-system">Earth’s reference
+coordinate system</dfn> defined as a three dimensional Cartesian coordinate system (x, y, z), where:</p>
    <ul>
     <li data-md="">
      <p>x-axis is a vector product of y.z that is tangential to the ground and points east,</p>
@@ -1673,19 +1677,20 @@ three dimensional Cartesian coordinate system (x, y, z), where:</p>
     <li data-md="">
      <p>z-axis points towards the sky and is perpendicular to the plane made up of x and y axes.</p>
    </ul>
-   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> is the same as defined by <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑥">low-level</a> motion sensors.</p>
-   <p class="note" role="note"><span>Note:</span> Figure below represents the case where device’s <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> and the <a data-link-type="dfn" href="#earths-reference-coordinate-system" id="ref-for-earths-reference-coordinate-system①">Earth’s reference coordinate system</a> are aligned, therefore,
+   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> is the same as defined for the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑥">low-level</a> motion sensors. It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
+   <p class="note" role="note"><span>Note:</span> Figure below represents the case where device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> and the <a data-link-type="dfn" href="#earths-reference-coordinate-system" id="ref-for-earths-reference-coordinate-system①">Earth’s reference coordinate system</a> are aligned, therefore,
 orientation sensor’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading③">latest reading</a> would represent 0 (rad) <a data-link-type="biblio" href="#biblio-si">[SI]</a> rotation about each axis.</p>
    <p><img alt="AbsoluteOrientationSensor coordinate system." src="images/absolute_orientation_sensor_coordinate_system.png" srcset="images/absolute_orientation_sensor_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <h3 class="heading settled" data-level="5.2" id="relativeorientationsensor-model"><span class="secno">5.2. </span><span class="content">The RelativeOrientationSensor Model</span><a class="self-link" href="#relativeorientationsensor-model"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor②">RelativeOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑦">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#relative-orientation" id="ref-for-relative-orientation">Relative Orientation Sensor</a>.</p>
    <p>For the relative orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading④">latest reading</a>["quaternion"] represents the
-rotation of a device hosting motion sensors in relation to a <a data-link-type="dfn" href="#stationary-reference-coordinate-system" id="ref-for-stationary-reference-coordinate-system">stationary reference coordinate
+rotation of a device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> in relation to a <a data-link-type="dfn" href="#stationary-reference-coordinate-system" id="ref-for-stationary-reference-coordinate-system">stationary reference coordinate
 system</a>. The <a data-link-type="dfn" href="#stationary-reference-coordinate-system" id="ref-for-stationary-reference-coordinate-system①">stationary reference coordinate system</a> may drift due to the bias introduced by
 the gyroscope sensor, thus, the rotation value provided by the sensor, may drift over time.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="stationary-reference-coordinate-system">stationary reference coordinate system</dfn> is defined as an inertial three dimensional
 Cartesian coordinate system that remains stationary as the device hosting the sensor moves through
 the environment.</p>
+   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> is the same as defined for the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑦">low-level</a> motion sensors. It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
    <p class="note" role="note"><span>Note:</span> The relative orientation sensor data could be more accurate than the one provided by absolute
 orientation sensor, as the sensor is not affected by magnetic fields.</p>
    <h2 class="heading settled" data-level="6" id="api"><span class="secno">6. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
@@ -1696,6 +1701,12 @@ orientation sensor, as the sensor is not affected by magnetic fields.</p>
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="orientationsensor"><code>OrientationSensor</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>>? <dfn class="nv idl-code" data-dfn-for="OrientationSensor" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<double>?" id="dom-orientationsensor-quaternion"><code>quaternion</code><a class="self-link" href="#dom-orientationsensor-quaternion"></a></dfn>;
   <span class="kt">void</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="OrientationSensor" data-dfn-type="method" data-export="" data-lt="populateMatrix(targetMatrix)" id="dom-orientationsensor-populatematrix"><code>populateMatrix</code></dfn>(<a class="n" data-link-type="idl-name" href="#typedefdef-rotationmatrixtype" id="ref-for-typedefdef-rotationmatrixtype">RotationMatrixType</a> <dfn class="nv idl-code" data-dfn-for="OrientationSensor/populateMatrix(targetMatrix)" data-dfn-type="argument" data-export="" id="dom-orientationsensor-populatematrix-targetmatrix-targetmatrix"><code>targetMatrix</code><a class="self-link" href="#dom-orientationsensor-populatematrix-targetmatrix-targetmatrix"></a></dfn>);
+};
+
+<span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-localcoordinatesystem"><code>LocalCoordinateSystem</code></dfn> { <dfn class="s idl-code" data-dfn-for="LocalCoordinateSystem" data-dfn-type="enum-value" data-export="" data-lt="&quot;device&quot;|device" id="dom-localcoordinatesystem-device"><code>"device"</code><a class="self-link" href="#dom-localcoordinatesystem-device"></a></dfn>, <dfn class="s idl-code" data-dfn-for="LocalCoordinateSystem" data-dfn-type="enum-value" data-export="" data-lt="&quot;screen&quot;|screen" id="dom-localcoordinatesystem-screen"><code>"screen"</code><a class="self-link" href="#dom-localcoordinatesystem-screen"></a></dfn> };
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-orientationsensoroptions"><code>OrientationSensorOptions</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a>  {
+  <a class="n" data-link-type="idl-name" href="#enumdef-localcoordinatesystem" id="ref-for-enumdef-localcoordinatesystem">LocalCoordinateSystem</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;device&quot;" data-dfn-for="OrientationSensorOptions" data-dfn-type="dict-member" data-export="" data-type="LocalCoordinateSystem " id="dom-orientationsensoroptions-referenceframe"><code>referenceFrame</code></dfn> = "device";
 };
 </pre>
    <h4 class="heading settled" data-level="6.1.1" id="orientationsensor-quaternion"><span class="secno">6.1.1. </span><span class="content">OrientationSensor.quaternion</span><a class="self-link" href="#orientationsensor-quaternion"></a></h4>
@@ -1815,20 +1826,44 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
     </ol>
    </div>
    <h3 class="heading settled" data-level="6.2" id="absoluteorientationsensor-interface"><span class="secno">6.2. </span><span class="content">The AbsoluteOrientationSensor Interface</span><a class="self-link" href="#absoluteorientationsensor-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="AbsoluteOrientationSensor" data-dfn-type="constructor" data-export="" data-lt="AbsoluteOrientationSensor(sensorOptions)|AbsoluteOrientationSensor()" id="dom-absoluteorientationsensor-absoluteorientationsensor"><code>Constructor</code><a class="self-link" href="#dom-absoluteorientationsensor-absoluteorientationsensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="AbsoluteOrientationSensor/AbsoluteOrientationSensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-absoluteorientationsensor-absoluteorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-absoluteorientationsensor-absoluteorientationsensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="AbsoluteOrientationSensor" data-dfn-type="constructor" data-export="" data-lt="AbsoluteOrientationSensor(sensorOptions)|AbsoluteOrientationSensor()" id="dom-absoluteorientationsensor-absoluteorientationsensor"><code>Constructor</code><a class="self-link" href="#dom-absoluteorientationsensor-absoluteorientationsensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-orientationsensoroptions" id="ref-for-dictdef-orientationsensoroptions">OrientationSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="AbsoluteOrientationSensor/AbsoluteOrientationSensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-absoluteorientationsensor-absoluteorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-absoluteorientationsensor-absoluteorientationsensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="absoluteorientationsensor"><code>AbsoluteOrientationSensor</code></dfn> : <a class="n" data-link-type="idl-name" href="#orientationsensor" id="ref-for-orientationsensor⑧">OrientationSensor</a> {
 };
 </pre>
-   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-absoluteorientationsensor-object">Construct an AbsoluteOrientationSensor Object<a class="self-link" href="#construct-an-absoluteorientationsensor-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
+   <p>To construct an <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor⑤">AbsoluteOrientationSensor</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-an-orientation-sensor-object" id="ref-for-construct-an-orientation-sensor-object">construct an orientation sensor object</a> abstract operation.</p>
    <h3 class="heading settled" data-level="6.3" id="relativeorientationsensor-interface"><span class="secno">6.3. </span><span class="content">The RelativeOrientationSensor Interface</span><a class="self-link" href="#relativeorientationsensor-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="RelativeOrientationSensor" data-dfn-type="constructor" data-export="" data-lt="RelativeOrientationSensor(sensorOptions)|RelativeOrientationSensor()" id="dom-relativeorientationsensor-relativeorientationsensor"><code>Constructor</code><a class="self-link" href="#dom-relativeorientationsensor-relativeorientationsensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="RelativeOrientationSensor/RelativeOrientationSensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="RelativeOrientationSensor" data-dfn-type="constructor" data-export="" data-lt="RelativeOrientationSensor(sensorOptions)|RelativeOrientationSensor()" id="dom-relativeorientationsensor-relativeorientationsensor"><code>Constructor</code><a class="self-link" href="#dom-relativeorientationsensor-relativeorientationsensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-orientationsensoroptions" id="ref-for-dictdef-orientationsensoroptions①">OrientationSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="RelativeOrientationSensor/RelativeOrientationSensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="relativeorientationsensor"><code>RelativeOrientationSensor</code></dfn> : <a class="n" data-link-type="idl-name" href="#orientationsensor" id="ref-for-orientationsensor⑨">OrientationSensor</a> {
 };
 </pre>
-   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-an-relativeorientationsensor-object">Construct an RelativeOrientationSensor Object<a class="self-link" href="#construct-an-relativeorientationsensor-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object①">construct a Sensor object</a> abstract operation.</p>
-   <h2 class="heading settled" data-level="7" id="acknowledgements"><span class="secno">7. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
+   <p>To construct a <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor③">RelativeOrientationSensor</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-an-orientation-sensor-object" id="ref-for-construct-an-orientation-sensor-object①">construct an orientation sensor object</a> abstract operation.</p>
+   <h2 class="heading settled" data-level="7" id="abstract-operations"><span class="secno">7. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
+   <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="7.1" data-lt="Construct an Orientation Sensor object" id="construct-an-orientation-sensor-object"><span class="secno">7.1. </span><span class="content">Construct an Orientation Sensor object</span></h3>
+   <div class="algorithm" data-algorithm="construct an orientation sensor object">
+    <dl>
+     <dt data-md="">input
+     <dd data-md="">
+      <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-orientationsensoroptions" id="ref-for-dictdef-orientationsensoroptions②">OrientationSensorOptions</a></code> object.</p>
+     <dt data-md="">output
+     <dd data-md="">
+      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor③">Sensor</a></code> object.</p>
+    </dl>
+    <ol>
+     <li data-md="">
+      <p>Let <var>sensor_instance</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> with <var>options</var>.</p>
+     <li data-md="">
+      <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-orientationsensoroptions-referenceframe" id="ref-for-dom-orientationsensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
+      <ol>
+       <li data-md="">
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system⑤">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system②">screen coordinate system</a>.</p>
+      </ol>
+     <li data-md="">
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system⑥">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system②">device coordinate system</a>.</p>
+    </ol>
+   </div>
+   <h2 class="heading settled" data-level="8" id="acknowledgements"><span class="secno">8. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API.</p>
-   <h2 class="heading settled" data-level="8" id="conformance"><span class="secno">8. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <h2 class="heading settled" data-level="9" id="conformance"><span class="secno">9. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
    <p>Conformance requirements are expressed with a combination of
 descriptive assertions and RFC 2119 terminology. The key words "MUST",
 "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
@@ -1850,19 +1885,25 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li><a href="#dom-absoluteorientationsensor-absoluteorientationsensor">AbsoluteOrientationSensor()</a><span>, in §6.2</span>
    <li><a href="#absoluteorientationsensor">AbsoluteOrientationSensor</a><span>, in §6.2</span>
    <li><a href="#dom-absoluteorientationsensor-absoluteorientationsensor">AbsoluteOrientationSensor(sensorOptions)</a><span>, in §6.2</span>
-   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §8</span>
-   <li><a href="#construct-an-absoluteorientationsensor-object">Construct an AbsoluteOrientationSensor Object</a><span>, in §6.2</span>
-   <li><a href="#construct-an-relativeorientationsensor-object">Construct an RelativeOrientationSensor Object</a><span>, in §6.3</span>
+   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §9</span>
+   <li><a href="#construct-an-orientation-sensor-object">Construct an Orientation Sensor object</a><span>, in §7</span>
+   <li><a href="#dom-localcoordinatesystem-device">device</a><span>, in §6.1</span>
+   <li><a href="#dom-localcoordinatesystem-device">"device"</a><span>, in §6.1</span>
    <li><a href="#earths-reference-coordinate-system">Earth’s reference coordinate system</a><span>, in §5.1</span>
-   <li><a href="#orientation-sensor">Orientation Sensor</a><span>, in §5</span>
+   <li><a href="#enumdef-localcoordinatesystem">LocalCoordinateSystem</a><span>, in §6.1</span>
    <li><a href="#orientationsensor">OrientationSensor</a><span>, in §6.1</span>
+   <li><a href="#orientation-sensor">Orientation Sensor</a><span>, in §5</span>
+   <li><a href="#dictdef-orientationsensoroptions">OrientationSensorOptions</a><span>, in §6.1</span>
    <li><a href="#dom-orientationsensor-populatematrix">populateMatrix(targetMatrix)</a><span>, in §6.1</span>
    <li><a href="#populate-rotation-matrix">populate rotation matrix</a><span>, in §6.1.2</span>
    <li><a href="#dom-orientationsensor-quaternion">quaternion</a><span>, in §6.1</span>
+   <li><a href="#dom-orientationsensoroptions-referenceframe">referenceFrame</a><span>, in §6.1</span>
    <li><a href="#relativeorientationsensor">RelativeOrientationSensor</a><span>, in §6.3</span>
    <li><a href="#dom-relativeorientationsensor-relativeorientationsensor">RelativeOrientationSensor()</a><span>, in §6.3</span>
    <li><a href="#dom-relativeorientationsensor-relativeorientationsensor">RelativeOrientationSensor(sensorOptions)</a><span>, in §6.3</span>
    <li><a href="#typedefdef-rotationmatrixtype">RotationMatrixType</a><span>, in §6.1</span>
+   <li><a href="#dom-localcoordinatesystem-screen">"screen"</a><span>, in §6.1</span>
+   <li><a href="#dom-localcoordinatesystem-screen">screen</a><span>, in §6.1</span>
    <li><a href="#stationary-reference-coordinate-system">stationary reference coordinate system</a><span>, in §5.2</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -1871,7 +1912,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <a data-link-type="biblio">[ACCELEROMETER]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/accelerometer#accelerometer">Accelerometer</a>
-     <li><a href="https://w3c.github.io/accelerometer#local-coordinate-system">local coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer#device-coordinate-system">device coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer#screen-coordinate-system">screen coordinate system</a>
     </ul>
    <li>
     <a data-link-type="biblio">[deviceorientation]</a> defines the following terms:
@@ -1887,6 +1929,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://w3c.github.io/sensors#equivalent">equivalent</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
      <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
      <li><a href="https://w3c.github.io/sensors#low-level">low-level</a>
      <li><a href="https://w3c.github.io/sensors/#dom-sensor-onerror">onerror</a>
      <li><a href="https://w3c.github.io/sensors/#request-sensor-access">request sensor access</a>
@@ -1947,17 +1990,17 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-accelerometer">[ACCELEROMETER]
-   <dd>Anssi Kostiainen; Alexander Shalamov. <a href="https://www.w3.org/TR/accelerometer/">Accelerometer</a>. 14 August 2017. WD. URL: <a href="https://www.w3.org/TR/accelerometer/">https://www.w3.org/TR/accelerometer/</a>
+   <dd>Anssi Kostiainen; Alexander Shalamov. <a href="https://www.w3.org/TR/accelerometer/">Accelerometer</a>. 18 October 2017. WD. URL: <a href="https://www.w3.org/TR/accelerometer/">https://www.w3.org/TR/accelerometer/</a>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
-   <dd>Rick Waldron; et al. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. 2 October 2017. WD. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
+   <dd>Rick Waldron; et al. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. 18 October 2017. WD. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
    <dt id="biblio-geometry-1">[GEOMETRY-1]
    <dd>Simon Pieters; Dirk Schulze; Rik Cabanier. <a href="https://www.w3.org/TR/geometry-1/">Geometry Interfaces Module Level 1</a>. 25 November 2014. CR. URL: <a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a>
    <dt id="biblio-gyroscope">[GYROSCOPE]
-   <dd>Anssi Kostiainen; Mikhail Pozdnyakov. <a href="https://www.w3.org/TR/gyroscope/">Gyroscope</a>. 14 August 2017. WD. URL: <a href="https://www.w3.org/TR/gyroscope/">https://www.w3.org/TR/gyroscope/</a>
+   <dd>Anssi Kostiainen; Mikhail Pozdnyakov. <a href="https://www.w3.org/TR/gyroscope/">Gyroscope</a>. 18 October 2017. WD. URL: <a href="https://www.w3.org/TR/gyroscope/">https://www.w3.org/TR/gyroscope/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-magnetometer">[MAGNETOMETER]
-   <dd>Anssi Kostiainen; Rijubrata Bhaumik. <a href="https://www.w3.org/TR/magnetometer/">Magnetometer</a>. 14 August 2017. WD. URL: <a href="https://www.w3.org/TR/magnetometer/">https://www.w3.org/TR/magnetometer/</a>
+   <dd>Anssi Kostiainen; Rijubrata Bhaumik. <a href="https://www.w3.org/TR/magnetometer/">Magnetometer</a>. 18 October 2017. WD. URL: <a href="https://www.w3.org/TR/magnetometer/">https://www.w3.org/TR/magnetometer/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WEBIDL]
@@ -1983,11 +2026,17 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <span class="kt">void</span> <a class="nv" href="#dom-orientationsensor-populatematrix"><code>populateMatrix</code></a>(<a class="n" data-link-type="idl-name" href="#typedefdef-rotationmatrixtype" id="ref-for-typedefdef-rotationmatrixtype②">RotationMatrixType</a> <a class="nv" href="#dom-orientationsensor-populatematrix-targetmatrix-targetmatrix"><code>targetMatrix</code></a>);
 };
 
-[<a class="nv" href="#dom-absoluteorientationsensor-absoluteorientationsensor"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①①">SensorOptions</a> <a class="nv" href="#dom-absoluteorientationsensor-absoluteorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>]
+<span class="kt">enum</span> <a class="nv" href="#enumdef-localcoordinatesystem"><code>LocalCoordinateSystem</code></a> { <a class="s" href="#dom-localcoordinatesystem-device"><code>"device"</code></a>, <a class="s" href="#dom-localcoordinatesystem-screen"><code>"screen"</code></a> };
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-orientationsensoroptions"><code>OrientationSensorOptions</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①①">SensorOptions</a>  {
+  <a class="n" data-link-type="idl-name" href="#enumdef-localcoordinatesystem" id="ref-for-enumdef-localcoordinatesystem①">LocalCoordinateSystem</a> <a class="nv" data-default="&quot;device&quot;" data-type="LocalCoordinateSystem " href="#dom-orientationsensoroptions-referenceframe"><code>referenceFrame</code></a> = "device";
+};
+
+[<a class="nv" href="#dom-absoluteorientationsensor-absoluteorientationsensor"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-orientationsensoroptions" id="ref-for-dictdef-orientationsensoroptions③">OrientationSensorOptions</a> <a class="nv" href="#dom-absoluteorientationsensor-absoluteorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#absoluteorientationsensor"><code>AbsoluteOrientationSensor</code></a> : <a class="n" data-link-type="idl-name" href="#orientationsensor" id="ref-for-orientationsensor⑧①">OrientationSensor</a> {
 };
 
-[<a class="nv" href="#dom-relativeorientationsensor-relativeorientationsensor"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions②①">SensorOptions</a> <a class="nv" href="#dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①">Exposed</a>=<span class="n">Window</span>]
+[<a class="nv" href="#dom-relativeorientationsensor-relativeorientationsensor"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-orientationsensoroptions" id="ref-for-dictdef-orientationsensoroptions①①">OrientationSensorOptions</a> <a class="nv" href="#dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#relativeorientationsensor"><code>RelativeOrientationSensor</code></a> : <a class="n" data-link-type="idl-name" href="#orientationsensor" id="ref-for-orientationsensor⑨①">OrientationSensor</a> {
 };
 
@@ -2035,6 +2084,26 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-dom-orientationsensor-populatematrix">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-dom-orientationsensor-populatematrix①">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="enumdef-localcoordinatesystem">
+   <b><a href="#enumdef-localcoordinatesystem">#enumdef-localcoordinatesystem</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-localcoordinatesystem">6.1. The OrientationSensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-orientationsensoroptions">
+   <b><a href="#dictdef-orientationsensoroptions">#dictdef-orientationsensoroptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-orientationsensoroptions">6.2. The AbsoluteOrientationSensor Interface</a>
+    <li><a href="#ref-for-dictdef-orientationsensoroptions①">6.3. The RelativeOrientationSensor Interface</a>
+    <li><a href="#ref-for-dictdef-orientationsensoroptions②">7.1. Construct an Orientation Sensor object</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-orientationsensoroptions-referenceframe">
+   <b><a href="#dom-orientationsensoroptions-referenceframe">#dom-orientationsensoroptions-referenceframe</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-orientationsensoroptions-referenceframe">7.1. Construct an Orientation Sensor object</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="populate-rotation-matrix">
    <b><a href="#populate-rotation-matrix">#populate-rotation-matrix</a></b><b>Referenced in:</b>
    <ul>
@@ -2047,6 +2116,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-absoluteorientationsensor">1. Introduction</a>
     <li><a href="#ref-for-absoluteorientationsensor①">5. Model</a> <a href="#ref-for-absoluteorientationsensor②">(2)</a> <a href="#ref-for-absoluteorientationsensor③">(3)</a>
     <li><a href="#ref-for-absoluteorientationsensor④">5.1. The AbsoluteOrientationSensor Model</a>
+    <li><a href="#ref-for-absoluteorientationsensor⑤">6.2. The AbsoluteOrientationSensor Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="relativeorientationsensor">
@@ -2054,6 +2124,14 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <ul>
     <li><a href="#ref-for-relativeorientationsensor">5. Model</a> <a href="#ref-for-relativeorientationsensor①">(2)</a>
     <li><a href="#ref-for-relativeorientationsensor②">5.2. The RelativeOrientationSensor Model</a>
+    <li><a href="#ref-for-relativeorientationsensor③">6.3. The RelativeOrientationSensor Interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="construct-an-orientation-sensor-object">
+   <b><a href="#construct-an-orientation-sensor-object">#construct-an-orientation-sensor-object</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-construct-an-orientation-sensor-object">6.2. The AbsoluteOrientationSensor Interface</a>
+    <li><a href="#ref-for-construct-an-orientation-sensor-object①">6.3. The RelativeOrientationSensor Interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This patch is a part of fix for https://github.com/w3c/sensors/issues/257.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/orientation-sensor/pull/53.html" title="Last updated on Feb 8, 2018, 2:40 PM GMT (9768904)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/53/f97a47c...pozdnyakov:9768904.html" title="Last updated on Feb 8, 2018, 2:40 PM GMT (9768904)">Diff</a>