### PR TITLE
Fix broken fragments, avoid redundant redirects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -25,7 +25,7 @@ Boilerplate: omit issues-index, omit conformance
 Ignored Vars: sensor_instance, targetMatrix, x, y, z, w
 </pre>
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
+urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
   type: dfn
     text: activated
     text: construct a sensor object; url: construct-sensor-object
@@ -40,7 +40,7 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: local coordinate system
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
     text: supported sensor options
-urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
+urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
   type: dfn
     text: acceleration
     text: device coordinate system
@@ -50,7 +50,7 @@ urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/gyroscope; spec: GYROSCOPE
+urlPrefix: https://w3c.github.io/gyroscope/; spec: GYROSCOPE
   type: dfn
     text: angular velocity
   type: interface
@@ -58,7 +58,7 @@ urlPrefix: https://w3c.github.io/gyroscope; spec: GYROSCOPE
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/magnetometer; spec: MAGNETOMETER
+urlPrefix: https://w3c.github.io/magnetometer/; spec: MAGNETOMETER
   type: dfn
     text: magnetic field
   type: interface
@@ -66,13 +66,13 @@ urlPrefix: https://w3c.github.io/magnetometer; spec: MAGNETOMETER
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://www.w3.org/TR/orientation-event; spec: DEVICEORIENTATION
+urlPrefix: https://www.w3.org/TR/2016/CR-orientation-event-20160818/; spec: DEVICEORIENTATION
   type: interface
     text: DeviceOrientationEvent; url: deviceorientation_event
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://w3c.github.io/motion-sensors; spec: MOTIONSENSORS
+urlPrefix: https://w3c.github.io/motion-sensors/; spec: MOTIONSENSORS
   type: dfn
     text: Absolute Orientation Sensor; url: absolute-orientation
     text: Relative Orientation Sensor; url: relative-orientation

--- a/index.html
+++ b/index.html
@@ -1183,8 +1183,9 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 5afc3ab5248efd53ff0fd6d61ad878a3dc5a357a" name="generator">
+  <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
   <link href="https://www.w3.org/TR/orientation-sensor/" rel="canonical">
+  <meta content="7fc313af3892922f4a32add1c8fadee9590e5703" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1431,7 +1432,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Orientation Sensor</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-13">13 March 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-14">14 March 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1546,14 +1547,14 @@ describes the device’s physical orientation in relation to the <a data-link-ty
 directions, such as true north, or non stationary directions, like in
 relation to a devices own z-position, drifting towards its latest most stable
 z-position.</p>
-   <p>The data provided by the <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor①">OrientationSensor</a></code> subclasses are similar to data from <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/orientation-event#deviceorientation_event" id="ref-for-deviceorientation_event">DeviceOrientationEvent</a></code>, but the Orientation Sensor API has the following significant differences:</p>
+   <p>The data provided by the <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor①">OrientationSensor</a></code> subclasses are similar to data from <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event" id="ref-for-deviceorientation_event">DeviceOrientationEvent</a></code>, but the Orientation Sensor API has the following significant differences:</p>
    <ol>
     <li data-md="">
      <p>The Orientation Sensor API represents orientation data in WebGL-compatible formats (quaternion, rotation matrix).</p>
     <li data-md="">
      <p>The Orientation Sensor API satisfies stricter latency requirements.</p>
     <li data-md="">
-     <p>Unlike <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/orientation-event#deviceorientation_event" id="ref-for-deviceorientation_event①">DeviceOrientationEvent</a></code>, the <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor②">OrientationSensor</a></code> subclasses explicitly define which <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level">low-level</a> motion sensors are used to obtain the orientation data, thus obviating possible interoperability issues.</p>
+     <p>Unlike <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event" id="ref-for-deviceorientation_event①">DeviceOrientationEvent</a></code>, the <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor②">OrientationSensor</a></code> subclasses explicitly define which <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level">low-level</a> motion sensors are used to obtain the orientation data, thus obviating possible interoperability issues.</p>
     <li data-md="">
      <p>Instances of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor③">OrientationSensor</a></code> subclasses are configurable via <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a></code> constructor parameter.</p>
    </ol>
@@ -1598,8 +1599,8 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
    <h2 class="heading settled" data-level="5" id="model"><span class="secno">5. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p>The <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor④">OrientationSensor</a></code> class extends the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor">Sensor</a></code> class and provides generic interface
 representing device orientation data.</p>
-   <p>To access the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="orientation-sensor">Orientation Sensor</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type">sensor type</a>’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading">latest reading</a>, the user agent must invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors/#request-sensor-access" id="ref-for-request-sensor-access">request sensor access</a> abstract operation for each of the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level①">low-level</a> sensors used by the concrete orientation sensor. The table below
-describes mapping between concrete orientation sensors and permission tokens defined by <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level②">low-level</a> sensors.</p>
+   <p>To access the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="orientation-sensor">Orientation Sensor</dfn> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-type" id="ref-for-sensor-type">sensor type</a>’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading">latest reading</a>, the user agent must invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors/#request-sensor-access" id="ref-for-request-sensor-access">request sensor access</a> abstract operation for each of the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level①">low-level</a> sensors used by the concrete orientation sensor. The table below
+describes mapping between concrete orientation sensors and permission tokens defined by <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level②">low-level</a> sensors.</p>
    <table class="def">
     <thead>
      <tr>
@@ -1614,29 +1615,29 @@ describes mapping between concrete orientation sensors and permission tokens def
       <td><code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor">RelativeOrientationSensor</a></code>
       <td>"<code>accelerometer</code>", "<code>gyroscope</code>"
    </table>
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading①">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor">Orientation Sensor</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a> is "quaternion" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> contains a four element <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a>.
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading①">latest reading</a> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#orientation-sensor" id="ref-for-orientation-sensor">Orientation Sensor</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a> is "quaternion" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> contains a four element <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a>.
 The elements of the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> are equal to components of a unit quaternion <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a> [V<sub>x</sub> * sin(θ/2), V<sub>y</sub> * sin(θ/2), V<sub>z</sub> * sin(θ/2), cos(θ/2)] where V is
 the unit vector (whose elements are V<sub>x</sub>, V<sub>y</sub>, and V<sub>z</sub>) representing the axis of rotation, and θ is the rotation angle about the axis defined by the unit vector V.</p>
    <p class="note" role="note"><span>Note:</span> The quaternion components are arranged in the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> as [q<sub>1</sub>, q<sub>2</sub>, q<sub>3</sub>, q<sub>0</sub>] <a data-link-type="biblio" href="#biblio-quaternions">[QUATERNIONS]</a>, i.e. the components representing the vector part of the quaternion go first and the scalar part component which
 is equal to cos(θ/2) goes after. This order is used for better compatibility with the most of the existing WebGL frameworks,
 however other libraries could use a different order when exposing quaternion as an array, e.g. [q<sub>0</sub>, q<sub>1</sub>,
 q<sub>2</sub>, q<sub>3</sub>].</p>
-   <p>The concrete <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑤">OrientationSensor</a></code> subclasses that are created through <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-fusion" id="ref-for-sensor-fusion">sensor-fusion</a> of the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level③">low-level</a> motion sensors are presented in the table below:</p>
+   <p>The concrete <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑤">OrientationSensor</a></code> subclasses that are created through <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-fusion" id="ref-for-sensor-fusion">sensor-fusion</a> of the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level③">low-level</a> motion sensors are presented in the table below:</p>
    <table class="def">
     <thead>
      <tr>
       <th>OrientationSensor sublass
-      <th><a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level④">Low-level</a> motion sensors
+      <th><a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level④">Low-level</a> motion sensors
     <tbody>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor②">AbsoluteOrientationSensor</a></code>
-      <td><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer#accelerometer" id="ref-for-accelerometer">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope#gyroscope" id="ref-for-gyroscope">Gyroscope</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/magnetometer#magnetometer" id="ref-for-magnetometer">Magnetometer</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer/#accelerometer" id="ref-for-accelerometer">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope/#gyroscope" id="ref-for-gyroscope">Gyroscope</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/magnetometer/#magnetometer" id="ref-for-magnetometer">Magnetometer</a></code>
     <tbody>
      <tr>
       <td><code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor①">RelativeOrientationSensor</a></code>
-      <td><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer#accelerometer" id="ref-for-accelerometer①">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope#gyroscope" id="ref-for-gyroscope①">Gyroscope</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer/#accelerometer" id="ref-for-accelerometer①">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope/#gyroscope" id="ref-for-gyroscope①">Gyroscope</a></code>
    </table>
-   <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer#accelerometer" id="ref-for-accelerometer②">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope#gyroscope" id="ref-for-gyroscope②">Gyroscope</a></code> and <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/magnetometer#magnetometer" id="ref-for-magnetometer①">Magnetometer</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑤">low-level</a> sensors are defined in <a data-link-type="biblio" href="#biblio-accelerometer">[ACCELEROMETER]</a>, <a data-link-type="biblio" href="#biblio-gyroscope">[GYROSCOPE]</a>, and <a data-link-type="biblio" href="#biblio-magnetometer">[MAGNETOMETER]</a> specifications respectively. The <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-fusion" id="ref-for-sensor-fusion①">sensor fusion</a> is platform specific and can happen in software or hardware, i.e.
+   <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/accelerometer/#accelerometer" id="ref-for-accelerometer②">Accelerometer</a></code>, <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/gyroscope/#gyroscope" id="ref-for-gyroscope②">Gyroscope</a></code> and <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/magnetometer/#magnetometer" id="ref-for-magnetometer①">Magnetometer</a></code> <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level⑤">low-level</a> sensors are defined in <a data-link-type="biblio" href="#biblio-accelerometer">[ACCELEROMETER]</a>, <a data-link-type="biblio" href="#biblio-gyroscope">[GYROSCOPE]</a>, and <a data-link-type="biblio" href="#biblio-magnetometer">[MAGNETOMETER]</a> specifications respectively. The <a data-link-type="dfn" href="https://w3c.github.io/sensors/#sensor-fusion" id="ref-for-sensor-fusion①">sensor fusion</a> is platform specific and can happen in software or hardware, i.e.
 on a sensor hub.</p>
    <div class="example" id="example-501d0803">
     <a class="self-link" href="#example-501d0803"></a> This example code explicitly queries permissions for <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor③">AbsoluteOrientationSensor</a></code> before
@@ -1665,9 +1666,9 @@ sensor<span class="p">.</span>onerror <span class="o">=</span> event <span class
    </div>
    <h3 class="heading settled" data-level="5.1" id="absoluteorientationsensor-model"><span class="secno">5.1. </span><span class="content">The AbsoluteOrientationSensor Model</span><a class="self-link" href="#absoluteorientationsensor-model"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor④">AbsoluteOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑥">OrientationSensor</a></code> which represents
-the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#absolute-orientation" id="ref-for-absolute-orientation">Absolute Orientation Sensor</a>.</p>
-   <p>For the absolute orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading②">latest reading</a>["quaternion"] represents
-the rotation of a device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> in relation to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Earth’s reference coordinate system" data-noexport="" id="earths-reference-coordinate-system">Earth’s reference
+the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors/#absolute-orientation" id="ref-for-absolute-orientation">Absolute Orientation Sensor</a>.</p>
+   <p>For the absolute orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading②">latest reading</a>["quaternion"] represents
+the rotation of a device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> in relation to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Earth’s reference coordinate system" data-noexport="" id="earths-reference-coordinate-system">Earth’s reference
 coordinate system</dfn> defined as a three dimensional Cartesian coordinate system (x, y, z), where:</p>
    <ul>
     <li data-md="">
@@ -1677,20 +1678,20 @@ coordinate system</dfn> defined as a three dimensional Cartesian coordinate syst
     <li data-md="">
      <p>z-axis points towards the sky and is perpendicular to the plane made up of x and y axes.</p>
    </ul>
-   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> is the same as defined for the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑥">low-level</a> motion sensors. It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
-   <p class="note" role="note"><span>Note:</span> Figure below represents the case where device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> and the <a data-link-type="dfn" href="#earths-reference-coordinate-system" id="ref-for-earths-reference-coordinate-system①">Earth’s reference coordinate system</a> are aligned, therefore,
-orientation sensor’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading③">latest reading</a> would represent 0 (rad) <a data-link-type="biblio" href="#biblio-si">[SI]</a> rotation about each axis.</p>
+   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> is the same as defined for the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level⑥">low-level</a> motion sensors. It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
+   <p class="note" role="note"><span>Note:</span> Figure below represents the case where device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a> and the <a data-link-type="dfn" href="#earths-reference-coordinate-system" id="ref-for-earths-reference-coordinate-system①">Earth’s reference coordinate system</a> are aligned, therefore,
+orientation sensor’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading③">latest reading</a> would represent 0 (rad) <a data-link-type="biblio" href="#biblio-si">[SI]</a> rotation about each axis.</p>
    <p><img alt="AbsoluteOrientationSensor coordinate system." src="images/absolute_orientation_sensor_coordinate_system.png" srcset="images/absolute_orientation_sensor_coordinate_system.svg" style="display: block;margin: auto;"></p>
    <h3 class="heading settled" data-level="5.2" id="relativeorientationsensor-model"><span class="secno">5.2. </span><span class="content">The RelativeOrientationSensor Model</span><a class="self-link" href="#relativeorientationsensor-model"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor②">RelativeOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑦">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors#relative-orientation" id="ref-for-relative-orientation">Relative Orientation Sensor</a>.</p>
-   <p>For the relative orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading④">latest reading</a>["quaternion"] represents the
-rotation of a device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> in relation to a <a data-link-type="dfn" href="#stationary-reference-coordinate-system" id="ref-for-stationary-reference-coordinate-system">stationary reference coordinate
+   <p>The <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor②">RelativeOrientationSensor</a></code> class is a subclass of <code class="idl"><a data-link-type="idl" href="#orientationsensor" id="ref-for-orientationsensor⑦">OrientationSensor</a></code> which represents the <a data-link-type="dfn" href="https://w3c.github.io/motion-sensors/#relative-orientation" id="ref-for-relative-orientation">Relative Orientation Sensor</a>.</p>
+   <p>For the relative orientation sensor the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading④">latest reading</a>["quaternion"] represents the
+rotation of a device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> in relation to a <a data-link-type="dfn" href="#stationary-reference-coordinate-system" id="ref-for-stationary-reference-coordinate-system">stationary reference coordinate
 system</a>. The <a data-link-type="dfn" href="#stationary-reference-coordinate-system" id="ref-for-stationary-reference-coordinate-system①">stationary reference coordinate system</a> may drift due to the bias introduced by
 the gyroscope sensor, thus, the rotation value provided by the sensor, may drift over time.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="stationary-reference-coordinate-system">stationary reference coordinate system</dfn> is defined as an inertial three dimensional
 Cartesian coordinate system that remains stationary as the device hosting the sensor moves through
 the environment.</p>
-   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> is the same as defined for the <a data-link-type="dfn" href="https://w3c.github.io/sensors#low-level" id="ref-for-low-level⑦">low-level</a> motion sensors. It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
+   <p>The device’s <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> is the same as defined for the <a data-link-type="dfn" href="https://w3c.github.io/sensors/#low-level" id="ref-for-low-level⑦">low-level</a> motion sensors. It can be either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a> or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
    <p class="note" role="note"><span>Note:</span> The relative orientation sensor data could be more accurate than the one provided by absolute
 orientation sensor, as the sensor is not affected by magnetic fields.</p>
    <h2 class="heading settled" data-level="6" id="api"><span class="secno">6. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
@@ -1715,7 +1716,7 @@ of the unit quaternion representing the device orientation.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <emu-val>this</emu-val> and "quaternion" as arguments.</p>
    <h4 class="heading settled" data-level="6.1.2" id="orientationsensor-populatematrix"><span class="secno">6.1.2. </span><span class="content">OrientationSensor.populateMatrix()</span><a class="self-link" href="#orientationsensor-populatematrix"></a></h4>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-orientationsensor-populatematrix" id="ref-for-dom-orientationsensor-populatematrix">populateMatrix()</a></code> method  populates the given object with rotation matrix
-which is converted from the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading⑤">latest reading</a>["quaternion"] <a data-link-type="biblio" href="#biblio-quatconv">[QUATCONV]</a>, as shown below:</p>
+which is converted from the value of <a data-link-type="dfn" href="https://w3c.github.io/sensors/#latest-reading" id="ref-for-latest-reading⑤">latest reading</a>["quaternion"] <a data-link-type="biblio" href="#biblio-quatconv">[QUATCONV]</a>, as shown below:</p>
    <p><img alt="Converting quaternion to rotation matrix." src="images/quaternion_to_rotation_matrix.png" style="display: block;margin: auto; width: 50%; height: 50%;"></p>
    <p>where:</p>
    <ul>
@@ -1731,7 +1732,7 @@ which is converted from the value of <a data-link-type="dfn" href="https://w3c.g
    <p>The rotation matrix is flattened in <var>targetMatrix</var> object according to the column-major order, as described in <a data-link-type="dfn" href="#populate-rotation-matrix" id="ref-for-populate-rotation-matrix">populate rotation matrix</a> algorighm.</p>
    <div class="algorithm" data-algorithm="populate rotation matrix">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="populate-rotation-matrix">populate rotation matrix</dfn>, the <code class="idl"><a data-link-type="idl" href="#dom-orientationsensor-populatematrix" id="ref-for-dom-orientationsensor-populatematrix①">populateMatrix()</a></code> method must
-run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sensors#equivalent" id="ref-for-equivalent">equivalent</a>: 
+run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sensors/#equivalent" id="ref-for-equivalent">equivalent</a>: 
     <ol>
      <li data-md="">
       <p>If <var>targetMatrix</var> is not of type defined by <code class="idl"><a data-link-type="idl" href="#typedefdef-rotationmatrixtype" id="ref-for-typedefdef-rotationmatrixtype①">RotationMatrixType</a></code> union, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">throw</a> a
@@ -1831,7 +1832,7 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
 };
 </pre>
    <p>To construct an <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor⑤">AbsoluteOrientationSensor</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-an-orientation-sensor-object" id="ref-for-construct-an-orientation-sensor-object">construct an orientation sensor object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor⑥">AbsoluteOrientationSensor</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor⑦">AbsoluteOrientationSensor</a></code> are
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#absoluteorientationsensor" id="ref-for-absoluteorientationsensor⑦">AbsoluteOrientationSensor</a></code> are
 "frequency" and "referenceFrame".</p>
    <h3 class="heading settled" data-level="6.3" id="relativeorientationsensor-interface"><span class="secno">6.3. </span><span class="content">The RelativeOrientationSensor Interface</span><a class="self-link" href="#relativeorientationsensor-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="RelativeOrientationSensor" data-dfn-type="constructor" data-export="" data-lt="RelativeOrientationSensor(sensorOptions)|RelativeOrientationSensor()" id="dom-relativeorientationsensor-relativeorientationsensor"><code>Constructor</code><a class="self-link" href="#dom-relativeorientationsensor-relativeorientationsensor"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-orientationsensoroptions" id="ref-for-dictdef-orientationsensoroptions①">OrientationSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="RelativeOrientationSensor/RelativeOrientationSensor(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-relativeorientationsensor-relativeorientationsensor-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
@@ -1839,7 +1840,7 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
 };
 </pre>
    <p>To construct a <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor③">RelativeOrientationSensor</a></code> object the user agent must invoke the <a data-link-type="dfn" href="#construct-an-orientation-sensor-object" id="ref-for-construct-an-orientation-sensor-object①">construct an orientation sensor object</a> abstract operation for the <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor④">RelativeOrientationSensor</a></code> interface.</p>
-   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors#supported-sensor-options" id="ref-for-supported-sensor-options①">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor⑤">RelativeOrientationSensor</a></code> are
+   <p><a data-link-type="dfn" href="https://w3c.github.io/sensors/#supported-sensor-options" id="ref-for-supported-sensor-options①">Supported sensor options</a> for <code class="idl"><a data-link-type="idl" href="#relativeorientationsensor" id="ref-for-relativeorientationsensor⑤">RelativeOrientationSensor</a></code> are
 "frequency" and "referenceFrame".</p>
    <h2 class="heading settled" data-level="7" id="abstract-operations"><span class="secno">7. </span><span class="content">Abstract Operations</span><a class="self-link" href="#abstract-operations"></a></h2>
    <h3 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="7.1" data-lt="Construct an Orientation Sensor object" id="construct-an-orientation-sensor-object"><span class="secno">7.1. </span><span class="content">Construct an Orientation Sensor object</span></h3>
@@ -1856,7 +1857,7 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> identified by <var>orientation_interface</var>.</p>
+      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features" id="ref-for-check-sensor-policy-controlled-features">check sensor policy-controlled features</a> with the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface①">interface</a> identified by <var>orientation_interface</var>.</p>
      <li data-md="">
       <p>If <var>allowed</var> is false, then:</p>
       <ol>
@@ -1866,15 +1867,15 @@ run these steps or their <a data-link-type="dfn" href="https://w3c.github.io/sen
      <li data-md="">
       <p>Let <var>orientation</var> be a new instance of the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface②">interface</a> identified by <var>orientation_interface</var>.</p>
      <li data-md="">
-      <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>orientation</var> and <var>options</var>.</p>
+      <p>Invoke <a data-link-type="dfn" href="https://w3c.github.io/sensors/#initialize-a-sensor-object" id="ref-for-initialize-a-sensor-object">initialize a sensor object</a> with <var>orientation</var> and <var>options</var>.</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-orientationsensoroptions-referenceframe" id="ref-for-dom-orientationsensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
       <ol>
        <li data-md="">
-        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system⑤">local coordinate system</a> for <var>orientation</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system②">screen coordinate system</a>.</p>
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system⑤">local coordinate system</a> for <var>orientation</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#screen-coordinate-system" id="ref-for-screen-coordinate-system②">screen coordinate system</a>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system⑥">local coordinate system</a> for <var>orientation</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system②">device coordinate system</a>.</p>
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors/#local-coordinate-system" id="ref-for-local-coordinate-system⑥">local coordinate system</a> for <var>orientation</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer/#device-coordinate-system" id="ref-for-device-coordinate-system②">device coordinate system</a>.</p>
      <li data-md="">
       <p>Return <var>orientation</var>.</p>
     </ol>
@@ -1929,33 +1930,33 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[ACCELEROMETER]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/accelerometer#accelerometer">Accelerometer</a>
-     <li><a href="https://w3c.github.io/accelerometer#device-coordinate-system">device coordinate system</a>
-     <li><a href="https://w3c.github.io/accelerometer#screen-coordinate-system">screen coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer/#accelerometer">Accelerometer</a>
+     <li><a href="https://w3c.github.io/accelerometer/#device-coordinate-system">device coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">screen coordinate system</a>
     </ul>
    <li>
     <a data-link-type="biblio">[deviceorientation]</a> defines the following terms:
     <ul>
-     <li><a href="https://www.w3.org/TR/orientation-event#deviceorientation_event">DeviceOrientationEvent</a>
+     <li><a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event">DeviceOrientationEvent</a>
     </ul>
    <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
-     <li><a href="https://w3c.github.io/sensors#equivalent">equivalent</a>
+     <li><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">check sensor policy-controlled features</a>
+     <li><a href="https://w3c.github.io/sensors/#equivalent">equivalent</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
-     <li><a href="https://w3c.github.io/sensors#initialize-a-sensor-object">initialize a sensor object</a>
-     <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
-     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
-     <li><a href="https://w3c.github.io/sensors#low-level">low-level</a>
+     <li><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">initialize a sensor object</a>
+     <li><a href="https://w3c.github.io/sensors/#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors/#local-coordinate-system">local coordinate system</a>
+     <li><a href="https://w3c.github.io/sensors/#low-level">low-level</a>
      <li><a href="https://w3c.github.io/sensors/#dom-sensor-onerror">onerror</a>
      <li><a href="https://w3c.github.io/sensors/#request-sensor-access">request sensor access</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
-     <li><a href="https://w3c.github.io/sensors#sensor-fusion">sensor-fusion</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-type">sensor type</a>
+     <li><a href="https://w3c.github.io/sensors/#sensor-fusion">sensor-fusion</a>
      <li><a href="https://w3c.github.io/sensors/#dom-sensor-start">start()</a>
-     <li><a href="https://w3c.github.io/sensors#supported-sensor-options">supported sensor options</a>
+     <li><a href="https://w3c.github.io/sensors/#supported-sensor-options">supported sensor options</a>
     </ul>
    <li>
     <a data-link-type="biblio">[geometry-1]</a> defines the following terms:
@@ -1965,7 +1966,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[GYROSCOPE]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/gyroscope#gyroscope">Gyroscope</a>
+     <li><a href="https://w3c.github.io/gyroscope/#gyroscope">Gyroscope</a>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -1983,13 +1984,13 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[MAGNETOMETER]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/magnetometer#magnetometer">Magnetometer</a>
+     <li><a href="https://w3c.github.io/magnetometer/#magnetometer">Magnetometer</a>
     </ul>
    <li>
     <a data-link-type="biblio">[motionsensors]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/motion-sensors#absolute-orientation">absolute orientation sensor</a>
-     <li><a href="https://w3c.github.io/motion-sensors#relative-orientation">relative orientation sensor</a>
+     <li><a href="https://w3c.github.io/motion-sensors/#absolute-orientation">absolute orientation sensor</a>
+     <li><a href="https://w3c.github.io/motion-sensors/#relative-orientation">relative orientation sensor</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:


### PR DESCRIPTION
- Fix Broken fragments:
  https://www.w3.org/TR/orientation-event#deviceorientation_event
  (Use the most recent dated TR that has not been gutted.)
- Avoid redundant redirects:
  https://w3c.github.io/sensors -> https://w3c.github.io/sensors/
  https://w3c.github.io/accelerometer -> https://w3c.github.io/accelerometer/
  https://w3c.github.io/gyroscope -> https://w3c.github.io/gyroscope/
  https://w3c.github.io/magnetometer -> https://w3c.github.io/magnetometer/
  https://w3c.github.io/motion-sensors -> https://w3c.github.io/motion-sensors/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/pull/58.html" title="Last updated on Mar 14, 2018, 2:46 PM GMT (561e485)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/58/7fc313a...561e485.html" title="Last updated on Mar 14, 2018, 2:46 PM GMT (561e485)">Diff</a>