### PR TITLE
fix: img width/height percentages to style

### DIFF
--- a/releases/FPWD.bs
+++ b/releases/FPWD.bs
@@ -267,7 +267,7 @@ In other words, this attribute returns [=latest reading=]["quaternion"].
 The {{OrientationSensor/populateMatrix()}} method  populates the given object with rotation matrix
 which is converted from the value of [=latest reading=]["quaternion"] [[QUATCONV]], as shown below:
 
-<img src="images/quaternion_to_rotation_matrix.png" style="display: block;margin: auto;" alt="Converting quaternion to rotation matrix." width="50%" height="50%">
+<img src="images/quaternion_to_rotation_matrix.png" style="display: block;margin: auto;width: 50%; height: 50%;" alt="Converting quaternion to rotation matrix.">
 
 where:
 


### PR DESCRIPTION
Percent values aren't allowed on these attributes.
Seems like HTML version was manually patched before