### PR TITLE
Fix bibliography link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -103,15 +103,10 @@ spec: webidl;
 <pre class=biblio>
 {
     "QUATERNIONS": {
-        "authors": [
-            "Kuipers, Jack B"
-        ],
         "id": "QUATERNIONS",
-        "href": "http://www.emis.ams.org/proceedings/Varna/vol1/GEOM09.pdf",
-        "title": "Quaternions and rotation sequences. Vol. 66.",
-        "date": "1999",
-        "status": "Informational",
-        "publisher": "Princeton university press"
+        "href": "https://en.wikipedia.org/wiki/Quaternion",
+        "title": "Quaternion",
+        "publisher": "Wikipedia"
     },
     "QUATCONV": {
         "authors": [


### PR DESCRIPTION
Fix #71.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/pull/72.html" title="Last updated on Jun 2, 2021, 11:48 AM UTC (dc05f8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/72/39507d8...dc05f8b.html" title="Last updated on Jun 2, 2021, 11:48 AM UTC (dc05f8b)">Diff</a>