### PR TITLE
Rewrite Automation section after w3c/sensors#470

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -492,7 +492,7 @@ Automation {#automation}
 
 This section extends [[GENERIC-SENSOR#automation]] by providing [=Orientation Sensor=]-specific virtual sensor metadata.
 
-<h3 dfn> Absolute Orientation Sensor automation</h3>
+<h3 id="absolute-orientation-sensor-automation">Absolute Orientation Sensor automation</h3>
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
@@ -500,7 +500,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 : [=map/value=]
 :: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Absolute Orientation Sensor=] and [=reading parsing algorithm=] is [=parse quaternion reading=].
 
-<h3 dfn>Relative Orientation Sensor automation</h3>
+<h3 id="relative-orientation-sensor-automation">Relative Orientation Sensor automation</h3>
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]

--- a/index.bs
+++ b/index.bs
@@ -501,15 +501,21 @@ Automation {#automation}
 
 This section extends [[GENERIC-SENSOR#automation]] by providing [=Orientation Sensor=]-specific virtual sensor metadata.
 
-<div algorithm>
-The <dfn>orientation reading parsing algorithm</dfn>, given a JSON {{Object}} |parameters|, must return the result of invoking [=parse quaternion reading=] with |parameters|.
-</div>
+<h3 dfn> Absolute Orientation Sensor automation</h3>
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`absolute-orientation`" or "`relative-orientation`"
+:: "`absolute-orientation`"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Orientation Sensor=] and [=reading parsing algorithm=] is [=orientation reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [[#absoluteorientationsensor-model|AbsoluteOrientationSensor]] and [=reading parsing algorithm=] is [=parse quaternion reading=].
+
+<h3 dfn>Relative Orientation Sensor automation</h3>
+
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`relative-orientation`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [[#relativeorientationsensor-model|RelativeOrientationSensor]] and [=reading parsing algorithm=] is [=parse quaternion reading=].
 
 Acknowledgements {#acknowledgements}
 ================

--- a/index.bs
+++ b/index.bs
@@ -498,7 +498,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 : [=map/key=]
 :: "`absolute-orientation`"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [[#absoluteorientationsensor-model|AbsoluteOrientationSensor]] and [=reading parsing algorithm=] is [=parse quaternion reading=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Absolute Orientation Sensor=] and [=reading parsing algorithm=] is [=parse quaternion reading=].
 
 <h3 dfn>Relative Orientation Sensor automation</h3>
 
@@ -506,7 +506,7 @@ The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/e
 : [=map/key=]
 :: "`relative-orientation`"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [[#relativeorientationsensor-model|RelativeOrientationSensor]] and [=reading parsing algorithm=] is [=parse quaternion reading=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Relative Orientation Sensor=] and [=reading parsing algorithm=] is [=parse quaternion reading=].
 
 Acknowledgements {#acknowledgements}
 ================

--- a/index.bs
+++ b/index.bs
@@ -48,9 +48,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: local coordinate system
     text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
     text: supported sensor options
-    text: automation
-    text: mock sensor type
-    text: mock sensor reading values
 urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
   type: dfn
     text: acceleration
@@ -501,31 +498,18 @@ Abstract Operations {#abstract-operations}
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the device's physical orientation in relation to a three
-dimensional Cartesian coordinate system for the purposes of testing a user agent's implementation
-of {{AbsoluteOrientationSensor}} and {{RelativeOrientationSensor}} APIs.
 
-<h3 id="mock-orientation-sensor-type">Mock Sensor Type</h3>
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Orientation Sensor=]-specific virtual sensor metadata.
 
-The {{AbsoluteOrientationSensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"absolute-orientation"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
+<div algorithm>
+The <dfn>orientation reading parsing algorithm</dfn>, given a JSON {{Object}} |parameters|, must return the result of invoking [=parse quaternion reading=] with |parameters|.
+</div>
 
-<pre class="idl">
-  dictionary AbsoluteOrientationReadingValues {
-    required FrozenArray&lt;double>? quaternion;
-  };
-</pre>
-
-The {{RelativeOrientationSensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"relative-orientation"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
-
-<pre class="idl">
-  dictionary RelativeOrientationReadingValues : AbsoluteOrientationReadingValues {
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`absolute-orientation`" or "`relative-orientation`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Orientation Sensor=] and [=reading parsing algorithm=] is [=orientation reading parsing algorithm=].
 
 Acknowledgements {#acknowledgements}
 ================


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Orientation Sensor spec to the changes:
* Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
* Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "absolute-orientation" or "relative-orientation" entry in MockSensorType and an appropriate virtual sensor metadata entry.

This is enough to integrate properly with the Generic Sensor spec and allow Orientation virtual sensors to be created and used.

Fixes #77.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JuhaVainio/orientation-sensor/pull/78.html" title="Last updated on Oct 25, 2023, 8:37 AM UTC (f1680ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/78/b4fe58d...JuhaVainio:f1680ff.html" title="Last updated on Oct 25, 2023, 8:37 AM UTC (f1680ff)">Diff</a>