### PR TITLE
Fix exception name used in permissions example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -289,11 +289,11 @@ on a sensor hub.
 
     <pre highlight="js">
     const sensor = new AbsoluteOrientationSensor();
-    sensor.start();
     sensor.onerror = event => {
-      if (event.error.name === 'SecurityError')
+      if (event.error.name === 'NotAllowedError')
         console.log("No permissions to use AbsoluteOrientationSensor.");
     };
+    sensor.start();
     </pre>
 </div>
 


### PR DESCRIPTION
When the permission checks in Sensor.start() fail, a NotAllowedError DOMException is created, not a SecurityError.

Additionally, add the event listener before invoking start() to avoid race conditions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/orientation-sensor/pull/79.html" title="Last updated on Oct 24, 2023, 11:21 AM UTC (bbe21fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/79/5dc2ade...rakuco:bbe21fe.html" title="Last updated on Oct 24, 2023, 11:21 AM UTC (bbe21fe)">Diff</a>