### PR TITLE
Define the Absolute/Relative Orientation Sensor sensor types in this spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -82,13 +82,6 @@ urlPrefix: https://www.w3.org/TR/2016/CR-orientation-event-20160818/; spec: DEVI
     text: DeviceOrientationEvent; url: deviceorientation_event
 </pre>
 
-<pre class="anchors">
-urlPrefix: https://w3c.github.io/motion-sensors/; spec: MOTIONSENSORS
-  type: dfn
-    text: Absolute Orientation Sensor; url: absolute-orientation
-    text: Relative Orientation Sensor; url: relative-orientation
-</pre>
-
 <pre class="link-defaults">
 spec:infra;
   type:dfn;
@@ -300,8 +293,7 @@ on a sensor hub.
 The AbsoluteOrientationSensor Model {#absoluteorientationsensor-model}
 ----------------------------------------------------------------------
 
-The {{AbsoluteOrientationSensor}} class is a subclass of {{OrientationSensor}} which represents
-the [=Absolute Orientation Sensor=].
+The <dfn id="absolute-orientation-sensor-type">Absolute Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#absolute-orientation]]. Its associated [=extension sensor interface=] is {{AbsoluteOrientationSensor}}, a subclass of {{OrientationSensor}}.
 
 For the absolute orientation sensor the value of [=latest reading=]["quaternion"] represents
 the rotation of a device's [=local coordinate system=] in relation to the <dfn>Earth's reference
@@ -323,8 +315,7 @@ orientation sensor's [=latest reading=] would represent 0 (rad) [[SI]] rotation 
 The RelativeOrientationSensor Model {#relativeorientationsensor-model}
 ----------------------------------------------------------------------
 
-The {{RelativeOrientationSensor}} class is a subclass of {{OrientationSensor}} which represents the
-[=Relative Orientation Sensor=].
+The <dfn id="relative-orientation-sensor-type">Relative Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#relative-orientation]]. Its associated [=extension sensor interface=] is {{RelativeOrientationSensor}}, a subclass of {{OrientationSensor}}.
 
 For the relative orientation sensor the value of [=latest reading=]["quaternion"] represents the
 rotation of a device's [=local coordinate system=] in relation to a [=stationary reference coordinate


### PR DESCRIPTION
Contrary to other specifications such as Accelerometer and Gyroscope, this specification did not define a sensor type for each of the concrete Orientation Sensors -- there was only a definition for Orientation Sensor itself.

The concept of inheritance between concepts is not really defined, so we should have sensor type definitions for absolute and relative orientation sensors explicitly written out as required by
https://w3c.github.io/sensors/#model-sensor-type, especially to fix #77, as some automation concepts are hooked to the "sensor type" concept.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/orientation-sensor/pull/80.html" title="Last updated on Oct 24, 2023, 11:23 AM UTC (ac00222)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/80/5dc2ade...rakuco:ac00222.html" title="Last updated on Oct 24, 2023, 11:23 AM UTC (ac00222)">Diff</a>