### PR TITLE
editorial: Export "Earth's reference coordinate system" <dfn>

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -293,7 +293,7 @@ The AbsoluteOrientationSensor Model {#absoluteorientationsensor-model}
 The <dfn id="absolute-orientation-sensor-type">Absolute Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#absolute-orientation]]. Its associated [=extension sensor interface=] is {{AbsoluteOrientationSensor}}, a subclass of {{OrientationSensor}}.
 
 For the absolute orientation sensor the value of [=latest reading=]["quaternion"] represents
-the rotation of a device's [=local coordinate system=] in relation to the <dfn>Earth's reference
+the rotation of a device's [=local coordinate system=] in relation to the <dfn export>Earth's reference
 coordinate system</dfn> defined as a three dimensional Cartesian coordinate system (x, y, z), where:
 
  - x-axis is a vector product of y.z that is tangential to the ground and points east,


### PR DESCRIPTION
This definition could be used by the Device Orientation API spec, so export
it here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/pull/81.html" title="Last updated on Nov 3, 2023, 12:56 PM UTC (24d2b8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/orientation-sensor/81/aff9350...24d2b8c.html" title="Last updated on Nov 3, 2023, 12:56 PM UTC (24d2b8c)">Diff</a>