### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13,7 +13,14 @@ Group: dap
 Abstract:
   This specification defines a base orientation sensor interface and concrete sensor subclasses to monitor the device's
   physical orientation in relation to a stationary three dimensional Cartesian coordinate system.
-Status Text:
+Status Text: <div class="advisement">
+  This specification is currently implemented in a single browser engine (Blink).
+  The [[DEVICE-ORIENTATION]] specification provides equivalent functionality and is implemented across major browser engines.
+  This specification is being maintained while websites migrate to [[DEVICE-ORIENTATION]].
+  Implementer standards positions:
+  <a href="https://github.com/WebKit/standards-positions/issues/347">WebKit</a>,
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  </div>
   The Devices and Sensors Working Group is pursuing modern security and privacy
   reviews for this specification in consideration of the amount of change in both
   this specification and in privacy and security review practices since the
@@ -22,6 +29,7 @@ Status Text:
   on 14 October 2019</a>. Similarly, the group is pursuing an update to the Technical
   Architecture Group review for this specification to account for the latest
   architectural review practices.
+
 Version History: https://github.com/w3c/orientation-sensor/commits/main/index.bs
 Issue Tracking: Orientation Sensor Issues Repository https://github.com/w3c/orientation-sensor/issues
 Indent: 2
@@ -196,16 +204,16 @@ describes mapping between concrete orientation sensors and permission tokens def
 
 <table class="def">
   <thead>
-    <th>OrientationSensor sublass</th>
-    <th>Permission tokens</th>
+    <tr>
+      <th>OrientationSensor sublass</th>
+      <th>Permission tokens</th>
+    </tr>
   </thead>
   <tbody>
     <tr>
       <td>{{AbsoluteOrientationSensor}}</td>
       <td>"<code>accelerometer</code>", "<code>gyroscope</code>", "<code>magnetometer</code>"</td>
     </tr>
-  </tbody>
-  <tbody>
     <tr>
       <td>{{RelativeOrientationSensor}}</td>
       <td>"<code>accelerometer</code>", "<code>gyroscope</code>"</td>
@@ -234,16 +242,16 @@ The concrete {{OrientationSensor}} subclasses that are created through [=sensor-
 
 <table class="def">
   <thead>
-    <th>OrientationSensor sublass</th>
-    <th>[=low-level|Low-level=] motion sensors</th>
+    <tr>
+      <th>OrientationSensor sublass</th>
+      <th>[=low-level|Low-level=] motion sensors</th>
+    </tr>
   </thead>
   <tbody>
     <tr>
       <td>{{AbsoluteOrientationSensor}}</td>
       <td>{{Accelerometer}}, {{Gyroscope}}, {{Magnetometer}}</td>
     </tr>
-  </tbody>
-  <tbody>
     <tr>
       <td>{{RelativeOrientationSensor}}</td>
       <td>{{Accelerometer}}, {{Gyroscope}}</td>


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.