### PR TITLE
Add implementation status note to SotD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14,6 +14,8 @@ Abstract:
   This specification defines a base orientation sensor interface and concrete sensor subclasses to monitor the device's
   physical orientation in relation to a stationary three dimensional Cartesian coordinate system.
 Status Text:
+  <p class="advisement">This specification is maintained for existing deployments. Multiple browser engines have expressed concerns about this specification. For new projects, developers should use <a href="https://www.w3.org/TR/orientation-event/">Device Orientation and Motion</a>, which has cross-engine support. The Working Group intends to develop new motion-sensing functionality in <a href="https://www.w3.org/TR/orientation-event/">Device Orientation and Motion</a>.</p>
+
   The Devices and Sensors Working Group is pursuing modern security and privacy
   reviews for this specification in consideration of the amount of change in both
   this specification and in privacy and security review practices since the


### PR DESCRIPTION
Addresses the TAG's 'at a glance' concern in design-reviews#1187.

The paragraph uses `<p class="advisement">` so it renders as a highlighted box, making the implementation-status signal visible at a glance rather than blending into the SotD boilerplate.

Reviewed in fork by @marcoscaceres and @jyasskin: https://github.com/christianliebel/orientation-sensor/pull/1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 14, 2026, 11:47 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fchristianliebel%2Forientation-sensor%2Fa93f146401cb640a6d3c37f024d332c1f88798bd%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "201:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "202:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "239:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "240:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "479:1",
        "messageType": "warning",
        "text": "At least one <img> doesn't have its size set (<img bs-line-number=\"479:1\" alt=\"Converting quaternion to rotation matrix.\" src=\"images/quaternion_to_rotation_matrix.png\" style=\"display: block;margin: auto; width: 50%; height: 50%;\">), but given the type of input document, Bikeshed can't figure out what the size should be.\nEither set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute."
    },
    {
        "lineNum": "184",
        "messageType": "warning",
        "text": "W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one."
    },
    {
        "lineNum": "295:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"295:5\" id=\"absolute-orientation-sensor-type\" data-dfn-type=\"dfn\" data-lt=\"Absolute Orientation Sensor\" data-noexport=\"by-default\" class=\"dfn-paneled\">Absolute Orientation Sensor</dfn>"
    },
    {
        "lineNum": "318:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"318:5\" id=\"relative-orientation-sensor-type\" data-dfn-type=\"dfn\" data-lt=\"Relative Orientation Sensor\" data-noexport=\"by-default\" class=\"dfn-paneled\">Relative Orientation Sensor</dfn>"
    },
    {
        "lineNum": "587:3",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"587:3\" data-dfn-type=\"dfn\" id=\"conformant-user-agent\" data-lt=\"conformant user agent\" data-noexport=\"by-default\" class=\"dfn-paneled\">conformant user agent</dfn>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/orientation-sensor%2387.)._

</details>
