### PR TITLE
Fix Bikeshed warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -29,7 +29,7 @@ Repository: w3c/orientation-sensor
 Markup Shorthands: markdown on
 Inline Github Issues: true
 !Test Suite: <a href="https://github.com/web-platform-tests/wpt/tree/master/orientation-sensor">web-platform-tests on GitHub</a>
-Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
+Boilerplate: omit issues-index, repository-issue-tracking no
 Include MDN Panels: if possible
 Ignored Vars: sensor_instance, targetMatrix, x, y, z, w
 </pre>
@@ -196,8 +196,10 @@ describes mapping between concrete orientation sensors and permission tokens def
 
 <table class="def">
   <thead>
-    <th>OrientationSensor sublass</th>
-    <th>Permission tokens</th>
+    <tr>
+      <th>OrientationSensor subclass</th>
+      <th>Permission tokens</th>
+    </tr>
   </thead>
   <tbody>
     <tr>
@@ -234,8 +236,10 @@ The concrete {{OrientationSensor}} subclasses that are created through [=sensor-
 
 <table class="def">
   <thead>
-    <th>OrientationSensor sublass</th>
-    <th>[=low-level|Low-level=] motion sensors</th>
+    <tr>
+      <th>OrientationSensor subclass</th>
+      <th>[=low-level|Low-level=] motion sensors</th>
+    </tr>
   </thead>
   <tbody>
     <tr>
@@ -290,7 +294,7 @@ on a sensor hub.
 The AbsoluteOrientationSensor Model {#absoluteorientationsensor-model}
 ----------------------------------------------------------------------
 
-The <dfn id="absolute-orientation-sensor-type">Absolute Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#absolute-orientation]]. Its associated [=extension sensor interface=] is {{AbsoluteOrientationSensor}}, a subclass of {{OrientationSensor}}. Its associated [=virtual sensor type=] is
+The <dfn id="absolute-orientation-sensor-type" export>Absolute Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#absolute-orientation]]. Its associated [=extension sensor interface=] is {{AbsoluteOrientationSensor}}, a subclass of {{OrientationSensor}}. Its associated [=virtual sensor type=] is
 "<code><a data-lt="absolute-orientation virtual sensor type">absolute-orientation</a></code>".
 
 For the absolute orientation sensor the value of [=latest reading=]["quaternion"] represents
@@ -313,7 +317,7 @@ orientation sensor's [=latest reading=] would represent 0 (rad) [[SI]] rotation 
 The RelativeOrientationSensor Model {#relativeorientationsensor-model}
 ----------------------------------------------------------------------
 
-The <dfn id="relative-orientation-sensor-type">Relative Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#relative-orientation]]. Its associated [=extension sensor interface=] is {{RelativeOrientationSensor}}, a subclass of {{OrientationSensor}}. Its associated [=virtual sensor type=] is
+The <dfn id="relative-orientation-sensor-type" export>Relative Orientation Sensor</dfn> [=sensor type=] represents the sensor described in [[MOTION-SENSORS#relative-orientation]]. Its associated [=extension sensor interface=] is {{RelativeOrientationSensor}}, a subclass of {{OrientationSensor}}. Its associated [=virtual sensor type=] is
 "<code><a data-lt="relative-orientation virtual sensor type">relative-orientation</a></code>".
 
 For the relative orientation sensor the value of [=latest reading=]["quaternion"] represents the
@@ -567,23 +571,3 @@ Acknowledgements {#acknowledgements}
 ================
 
 Tobie Langel for the work on Generic Sensor API.
-
-Conformance {#conformance}
-===========
-
-Conformance requirements are expressed with a combination of
-descriptive assertions and RFC 2119 terminology. The key words "MUST",
-"MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-"RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
-document are to be interpreted as described in RFC 2119.
-However, for readability, these words do not appear in all uppercase
-letters in this specification.
-
-All of the text of this specification is normative except sections
-explicitly marked as non-normative, examples, and notes. [[!RFC2119]]
-
-A <dfn>conformant user agent</dfn> must implement all the requirements
-listed in this specification that are applicable to user agents.
-
-The IDL fragments in this specification must be interpreted as required for
-conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]


### PR DESCRIPTION
The absolute and relative orientation sensor type definitions need to be explicitly exported and the Conformance section has been replaced by the standard Bikeshed boilerplate which doesn't contain an invalid reference to "conformant user agent".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 14, 2026, 8:50 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Forientation-sensor%2F70fe2300448ea3d8259d0f13f689138fedbdcd9f%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "199:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "200:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "237:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "238:5",
        "messageType": "fatal",
        "text": "Saw a <th> that wasn't in a <tr>"
    },
    {
        "lineNum": "477:1",
        "messageType": "warning",
        "text": "At least one <img> doesn't have its size set (<img bs-line-number=\"477:1\" alt=\"Converting quaternion to rotation matrix.\" src=\"images/quaternion_to_rotation_matrix.png\" style=\"display: block;margin: auto; width: 50%; height: 50%;\">), but given the type of input document, Bikeshed can't figure out what the size should be.\nEither set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute."
    },
    {
        "lineNum": "182",
        "messageType": "warning",
        "text": "W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one."
    },
    {
        "lineNum": "293:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"293:5\" id=\"absolute-orientation-sensor-type\" data-dfn-type=\"dfn\" data-lt=\"Absolute Orientation Sensor\" data-noexport=\"by-default\" class=\"dfn-paneled\">Absolute Orientation Sensor</dfn>"
    },
    {
        "lineNum": "316:5",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"316:5\" id=\"relative-orientation-sensor-type\" data-dfn-type=\"dfn\" data-lt=\"Relative Orientation Sensor\" data-noexport=\"by-default\" class=\"dfn-paneled\">Relative Orientation Sensor</dfn>"
    },
    {
        "lineNum": "585:3",
        "messageType": "lint",
        "text": "Unexported dfn that's not referenced locally - did you mean to export it?\n<dfn bs-line-number=\"585:3\" data-dfn-type=\"dfn\" id=\"conformant-user-agent\" data-lt=\"conformant user agent\" data-noexport=\"by-default\" class=\"dfn-paneled\">conformant user agent</dfn>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/orientation-sensor%2388.)._

</details>
